### PR TITLE
Adding api version header to all refit endpoints

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Constants.cs
+++ b/src/Umbraco.Headless.Client.Net/Constants.cs
@@ -6,6 +6,7 @@ namespace Umbraco.Headless.Client.Net
     public static class Constants
     {
         public const string ApiVersion = "2.1";
+        public const string ApiVersionHeader = Headers.ApiVersion + ": " + ApiVersion;
 
         public static class Urls
         {

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
@@ -4,7 +4,7 @@ using Refit;
 
 namespace Umbraco.Headless.Client.Net.Delivery
 {
-
+    [Headers(Constants.ApiVersionHeader)]
     interface ContentDeliveryEndpoints
     {
         [Get("/content?hyperlinks=false")]
@@ -32,6 +32,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.PagedContent> Search([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string term, int page, int pageSize);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface TypedContentRootDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
         [Get("/content?contentType={contentType}&hyperlinks=false")]
@@ -41,6 +42,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.RootContent<T>> GetAncestors([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface TypedPagedContentDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
         [Get("/content/{id}/children?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
@@ -53,6 +55,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.PagedContent<T>> GetByType([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType, int page, int pageSize);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface TypedContentDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
         [Get("/content/{id}?depth={depth}&contentType={contentType}&hyperlinks=false")]
@@ -62,6 +65,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<T> GetByUrl([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string url, string contentType, int depth);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface MediaDeliveryEndpoints
     {
         [Get("/media?hyperlinks=false")]
@@ -74,6 +78,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.PagedMedia> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, int page, int pageSize);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface TypedMediaDeliveryEndpoints<T> where T : Delivery.Models.IMedia
     {
         [Get("/media?hyperlinks=false")]

--- a/src/Umbraco.Headless.Client.Net/Management/ContentManagementEndpoints.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/ContentManagementEndpoints.cs
@@ -5,6 +5,7 @@ using Umbraco.Headless.Client.Net.Management.Models;
 
 namespace Umbraco.Headless.Client.Net.Management
 {
+    [Headers(Constants.ApiVersionHeader)]
     interface ContentManagementEndpoints
     {
         [Post("/content")]
@@ -40,6 +41,7 @@ namespace Umbraco.Headless.Client.Net.Management
             string projectAlias, Guid id, string culture);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface MediaManagementEndpoints
      {
         [Post("/media")]
@@ -62,8 +64,9 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<Media> Update([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, Media media);
      }
 
-     interface MemberManagementEndpoints
-     {
+    [Headers(Constants.ApiVersionHeader)]
+    interface MemberManagementEndpoints
+    {
         [Post("/member")]
         Task<Member> Create([Header(Constants.Headers.ProjectAlias)] string projectAlias, Member member);
 
@@ -81,8 +84,9 @@ namespace Umbraco.Headless.Client.Net.Management
 
         [Delete("/member/{username}/groups/{groupName}")]
         Task RemoveFromGroup([Header(Constants.Headers.ProjectAlias)] string projectAlias, string username, string groupname);
-      }
+    }    
 
+    [Headers(Constants.ApiVersionHeader)]
     interface DocumentTypeManagementEndpoints
     {
         [Get("/content/type")]
@@ -92,6 +96,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<DocumentType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface MediaTypeManagementEndpoints
     {
         [Get("/media/type")]
@@ -101,6 +106,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<MediaType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface MemberTypeManagementEndpoints
     {
         [Get("/member/type")]
@@ -110,6 +116,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<MemberType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface MemberGroupManagementEndpoints
     {
         [Get("/member/group")]
@@ -125,6 +132,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<MemberGroup> Delete([Header(Constants.Headers.ProjectAlias)] string projectAlias, string name);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface LanguageManagementEndpoints
     {
         [Get("/language")]
@@ -143,6 +151,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<Language> Delete([Header(Constants.Headers.ProjectAlias)] string projectAlias, string isoCode);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface RelationTypeManagementEndpoints
     {
         [Get("/relation/type")]
@@ -152,6 +161,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<RelationType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface RelationManagementEndpoints
     {
         [Get("/relation/{id}")]
@@ -179,6 +189,7 @@ namespace Umbraco.Headless.Client.Net.Management
             string projectAlias, int id);
     }
 
+    [Headers(Constants.ApiVersionHeader)]
     interface FormManagementEndpoints
     {
         [Get("/forms")]


### PR DESCRIPTION
This PR introduces the use of the `api-version` header via Refit interfaces.