### PR TITLE
Adding a method for getting content by content type where the alias i…

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
@@ -125,9 +125,13 @@ namespace Umbraco.Headless.Client.Net.Delivery
         public async Task<PagedContent<T>> GetByType<T>(string culture = null, int page = 1, int pageSize = 10) where T : IContent
         {
             var contentType = GetAliasFromClassName<T>();
+            return await GetByTypeAlias<T>(contentType, culture, page, pageSize);
+        }
 
+        public async Task<PagedContent<T>> GetByTypeAlias<T>(string contentTypeAlias, string culture = null, int page = 1, int pageSize = 10) where T : IContent
+        {
             var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetByType(_configuration.ProjectAlias, culture, contentType, page, pageSize);
+            var content = await service.GetByType(_configuration.ProjectAlias, culture, contentTypeAlias, page, pageSize);
             return content;
         }
 

--- a/src/Umbraco.Headless.Client.Net/Delivery/IContentDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/IContentDelivery.cs
@@ -136,12 +136,30 @@ namespace Umbraco.Headless.Client.Net.Delivery
         /// <summary>
         /// Gets all Content of a specific type
         /// </summary>
+        /// <remarks>
+        /// The Content Type alias is derived from the class type name.
+        /// </remarks>
         /// <typeparam name="T">A type that inherits from the <see cref="IContent"/> interface</typeparam>
         /// <param name="culture">Content Culture (Optional)</param>
         /// <param name="page">Integer specifying the page number (Optional)</param>
         /// <param name="pageSize">Integer specifying the page size (Optional)</param>
         /// <returns><see cref="PagedContent{T}"/></returns>
         Task<PagedContent<T>> GetByType<T>(string culture = null, int page = 1, int pageSize = 10) where T : IContent;
+
+        /// <summary>
+        /// Gets all Content of a specific type
+        /// </summary>
+        /// <remarks>
+        /// This allows manual specification of the Content Type alias instead of deriving it from the class type name.
+        /// </remarks>
+        /// <typeparam name="T">A type that inherits from the <see cref="IContent"/> interface</typeparam>
+        /// <param name="contentTypeAlias">Alias of the ContentType</param>
+        /// <param name="culture">Content Culture (Optional)</param>
+        /// <param name="page">Integer specifying the page number (Optional)</param>
+        /// <param name="pageSize">Integer specifying the page size (Optional)</param>
+        /// <returns><see cref="PagedContent{T}"/></returns>
+        Task<PagedContent<T>> GetByTypeAlias<T>(string contentTypeAlias, string culture = null, int page = 1,
+            int pageSize = 10) where T : IContent;
 
         /// <summary>
         /// Filter content based on property value and optionally content type

--- a/test/Umbraco.Headless.Client.Net.Tests/TypedContentDeliveryFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/TypedContentDeliveryFixture.cs
@@ -59,7 +59,26 @@ namespace Umbraco.Headless.Client.Net.Tests
         {
             var service = new ContentDeliveryService(_configuration,
                 GetMockedHttpClient($"{_contentBaseUrl}/type?contentType={contentType}", ContentDeliveryJson.GetByType));
-            var pagedContent = await service.Content.GetByType<Product>(contentType);
+            var pagedContent = await service.Content.GetByType<Product>();
+            Assert.NotNull(pagedContent);
+            Assert.NotNull(pagedContent.Content);
+            Assert.NotEmpty(pagedContent.Content.Items);
+            Assert.Equal(1, pagedContent.TotalPages);
+            Assert.Equal(8, pagedContent.TotalItems);
+            foreach (var contentItem in pagedContent.Content.Items)
+            {
+                Assert.NotNull(contentItem);
+                Assert.False(string.IsNullOrEmpty(contentItem.ProductName));
+            }
+        }
+
+        [Theory]
+        [InlineData("product")]
+        public async Task Can_Retrieve_Content_By_TypeAlias_Typed(string contentTypeAlias)
+        {
+            var service = new ContentDeliveryService(_configuration,
+                GetMockedHttpClient($"{_contentBaseUrl}/type?contentType={contentTypeAlias}", ContentDeliveryJson.GetByType));
+            var pagedContent = await service.Content.GetByTypeAlias<Product>(contentTypeAlias);
             Assert.NotNull(pagedContent);
             Assert.NotNull(pagedContent.Content);
             Assert.NotEmpty(pagedContent.Content.Items);


### PR DESCRIPTION
…s specified through a string parameter.

This PR addresses the first part of the request in #11 

With `GetByTypeAlias` you can get the typed content back and specify the alias through a string parameter in case the class name doesn't match the class name (type).