### PR TITLE
Updating how the api-version header is applied when calling endpoints

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Constants.cs
+++ b/src/Umbraco.Headless.Client.Net/Constants.cs
@@ -11,12 +11,12 @@ namespace Umbraco.Headless.Client.Net
          * In this library we mark the methods that support newly released features/endpoints
          * with the version from when they were available.
          * Ie. Forms was introduced in 2.1, so those endpoints send that version header.
-         * All existing (original) endpoints don't send any version header as they are on
+         * All existing (original) endpoints will send the minimum version header as they are on
          * the minimum version, which is 2.0.
          */
 
         //Minimum version for this Library
-        public const string ApiMinimumVersion = "2.1";
+        public const string ApiMinimumVersion = "2.0";
         public const string ApiMinimumVersionHeader = Headers.ApiVersion + ": " + ApiMinimumVersion;
         //Current version for this library
         public const string ApiVersion = "2.1";

--- a/src/Umbraco.Headless.Client.Net/Constants.cs
+++ b/src/Umbraco.Headless.Client.Net/Constants.cs
@@ -5,6 +5,20 @@ namespace Umbraco.Headless.Client.Net
 {
     public static class Constants
     {
+        /* A note on api versions and the version http header:
+         * When a new version is released on Umbraco Cloud, new endpoints
+         * will be available from that version forward.
+         * In this library we mark the methods that support newly released features/endpoints
+         * with the version from when they were available.
+         * Ie. Forms was introduced in 2.1, so those endpoints send that version header.
+         * All existing (original) endpoints don't send any version header as they are on
+         * the minimum version, which is 2.0.
+         */
+
+        //Minimum version for this Library
+        public const string ApiMinimumVersion = "2.1";
+        public const string ApiMinimumVersionHeader = Headers.ApiVersion + ": " + ApiMinimumVersion;
+        //Current version for this library
         public const string ApiVersion = "2.1";
         public const string ApiVersionHeader = Headers.ApiVersion + ": " + ApiVersion;
 

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
@@ -5,6 +5,7 @@ using Umbraco.Headless.Client.Net.Delivery.Models;
 
 namespace Umbraco.Headless.Client.Net.Delivery
 {
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface ContentDeliveryEndpoints
     {
         [Get("/content?hyperlinks=false")]
@@ -36,6 +37,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.PagedContent> Search([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string term, int page, int pageSize);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface TypedContentRootDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
         [Get("/content?contentType={contentType}&hyperlinks=false")]
@@ -45,6 +47,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.RootContent<T>> GetAncestors([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface TypedPagedContentDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
         [Get("/content/{id}/children?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
@@ -60,6 +63,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.PagedContent<T>> Filter([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, [Body] ContentFilter filter, int page, int pageSize);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface TypedContentDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
         [Get("/content/{id}?depth={depth}&contentType={contentType}&hyperlinks=false")]
@@ -69,6 +73,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<T> GetByUrl([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string url, string contentType, int depth);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface MediaDeliveryEndpoints
     {
         [Get("/media?hyperlinks=false")]
@@ -81,6 +86,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.PagedMedia> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, int page, int pageSize);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface TypedMediaDeliveryEndpoints<T> where T : Delivery.Models.IMedia
     {
         [Get("/media?hyperlinks=false")]

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
@@ -5,7 +5,6 @@ using Umbraco.Headless.Client.Net.Delivery.Models;
 
 namespace Umbraco.Headless.Client.Net.Delivery
 {
-    [Headers(Constants.ApiVersionHeader)]
     interface ContentDeliveryEndpoints
     {
         [Get("/content?hyperlinks=false")]
@@ -29,6 +28,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         [Get("/content/type?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
         Task<Delivery.Models.PagedContent> GetByType([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType, int page, int pageSize);
 
+        [Headers(Constants.ApiVersionHeader)]
         [Post("/content/filter?page={page}&pageSize={pageSize}&hyperlinks=false")]
         Task<Delivery.Models.PagedContent> Filter([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, [Body] ContentFilter filter, int page, int pageSize);
 
@@ -36,7 +36,6 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.PagedContent> Search([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string term, int page, int pageSize);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface TypedContentRootDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
         [Get("/content?contentType={contentType}&hyperlinks=false")]
@@ -46,7 +45,6 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.RootContent<T>> GetAncestors([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface TypedPagedContentDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
         [Get("/content/{id}/children?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
@@ -62,7 +60,6 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.PagedContent<T>> Filter([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, [Body] ContentFilter filter, int page, int pageSize);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface TypedContentDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
         [Get("/content/{id}?depth={depth}&contentType={contentType}&hyperlinks=false")]
@@ -72,7 +69,6 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<T> GetByUrl([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string url, string contentType, int depth);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface MediaDeliveryEndpoints
     {
         [Get("/media?hyperlinks=false")]
@@ -85,7 +81,6 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<Delivery.Models.PagedMedia> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, int page, int pageSize);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface TypedMediaDeliveryEndpoints<T> where T : Delivery.Models.IMedia
     {
         [Get("/media?hyperlinks=false")]

--- a/src/Umbraco.Headless.Client.Net/Management/ContentManagementEndpoints.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/ContentManagementEndpoints.cs
@@ -5,6 +5,7 @@ using Umbraco.Headless.Client.Net.Management.Models;
 
 namespace Umbraco.Headless.Client.Net.Management
 {
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface ContentManagementEndpoints
     {
         [Post("/content")]
@@ -40,8 +41,9 @@ namespace Umbraco.Headless.Client.Net.Management
             string projectAlias, Guid id, string culture);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface MediaManagementEndpoints
-     {
+    {
         [Post("/media")]
         Task<Management.Models.Media> Create([Header(Constants.Headers.ProjectAlias)] string projectAlias, Management.Models.Media media);
 
@@ -60,8 +62,9 @@ namespace Umbraco.Headless.Client.Net.Management
 
         [Put("/media/{id}")]
         Task<Management.Models.Media> Update([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, Management.Models.Media media);
-     }
+    }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface MemberManagementEndpoints
     {
         [Post("/member")]
@@ -81,8 +84,9 @@ namespace Umbraco.Headless.Client.Net.Management
 
         [Delete("/member/{username}/groups/{groupName}")]
         Task RemoveFromGroup([Header(Constants.Headers.ProjectAlias)] string projectAlias, string username, string groupname);
-    }    
+    }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface DocumentTypeManagementEndpoints
     {
         [Get("/content/type")]
@@ -92,6 +96,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<DocumentType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface MediaTypeManagementEndpoints
     {
         [Get("/media/type")]
@@ -101,6 +106,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<MediaType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface MemberTypeManagementEndpoints
     {
         [Get("/member/type")]
@@ -110,6 +116,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<MemberType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface MemberGroupManagementEndpoints
     {
         [Get("/member/group")]
@@ -125,6 +132,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<MemberGroup> Delete([Header(Constants.Headers.ProjectAlias)] string projectAlias, string name);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface LanguageManagementEndpoints
     {
         [Get("/language")]
@@ -143,6 +151,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<Language> Delete([Header(Constants.Headers.ProjectAlias)] string projectAlias, string isoCode);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface RelationTypeManagementEndpoints
     {
         [Get("/relation/type")]
@@ -152,6 +161,7 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<RelationType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
+    [Headers(Constants.ApiMinimumVersionHeader)]
     interface RelationManagementEndpoints
     {
         [Get("/relation/{id}")]

--- a/src/Umbraco.Headless.Client.Net/Management/ContentManagementEndpoints.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/ContentManagementEndpoints.cs
@@ -5,7 +5,6 @@ using Umbraco.Headless.Client.Net.Management.Models;
 
 namespace Umbraco.Headless.Client.Net.Management
 {
-    [Headers(Constants.ApiVersionHeader)]
     interface ContentManagementEndpoints
     {
         [Post("/content")]
@@ -41,7 +40,6 @@ namespace Umbraco.Headless.Client.Net.Management
             string projectAlias, Guid id, string culture);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface MediaManagementEndpoints
      {
         [Post("/media")]
@@ -64,7 +62,6 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<Management.Models.Media> Update([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, Management.Models.Media media);
      }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface MemberManagementEndpoints
     {
         [Post("/member")]
@@ -86,7 +83,6 @@ namespace Umbraco.Headless.Client.Net.Management
         Task RemoveFromGroup([Header(Constants.Headers.ProjectAlias)] string projectAlias, string username, string groupname);
     }    
 
-    [Headers(Constants.ApiVersionHeader)]
     interface DocumentTypeManagementEndpoints
     {
         [Get("/content/type")]
@@ -96,7 +92,6 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<DocumentType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface MediaTypeManagementEndpoints
     {
         [Get("/media/type")]
@@ -106,7 +101,6 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<MediaType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface MemberTypeManagementEndpoints
     {
         [Get("/member/type")]
@@ -116,7 +110,6 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<MemberType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface MemberGroupManagementEndpoints
     {
         [Get("/member/group")]
@@ -132,7 +125,6 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<MemberGroup> Delete([Header(Constants.Headers.ProjectAlias)] string projectAlias, string name);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface LanguageManagementEndpoints
     {
         [Get("/language")]
@@ -151,7 +143,6 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<Language> Delete([Header(Constants.Headers.ProjectAlias)] string projectAlias, string isoCode);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface RelationTypeManagementEndpoints
     {
         [Get("/relation/type")]
@@ -161,7 +152,6 @@ namespace Umbraco.Headless.Client.Net.Management
         Task<RelationType> ByAlias([Header(Constants.Headers.ProjectAlias)] string projectAlias, string alias);
     }
 
-    [Headers(Constants.ApiVersionHeader)]
     interface RelationManagementEndpoints
     {
         [Get("/relation/{id}")]


### PR DESCRIPTION
This PR addresses the potential issue of sending the latest api-version header across for all endpoints.
Instead we only send the latest api-version for features that were added in that new version. All original endpoints don't send an api-version header, so they default to that of the running Umbraco Heartcore project.