### PR TITLE
Filter results as T

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
@@ -135,6 +135,17 @@ namespace Umbraco.Headless.Client.Net.Delivery
             return content;
         }
 
+        public async Task<PagedContent<T>> Filter<T>(ContentFilter filter, string culture = null, int page = 1, int pageSize = 10) where T : IContent
+        {
+            if(filter == null || filter.Properties.Length == 0)
+                throw new ArgumentException("ContentFilter should contain at least one property to filter on");
+            
+            filter.ContentTypeAlias = filter.ContentTypeAlias ?? GetAliasFromClassName<T>();
+
+            var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
+            var content = await service.Filter(_configuration.ProjectAlias, culture, filter, page, pageSize);
+            return content;
+        }
         public async Task<PagedContent> Filter(ContentFilter filter, string culture = null, int page = 1, int pageSize = 10)
         {
             if(filter == null || filter.Properties.Length == 0)

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
@@ -57,6 +57,9 @@ namespace Umbraco.Headless.Client.Net.Delivery
 
         [Get("/content/type?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
         Task<Delivery.Models.PagedContent<T>> GetByType([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType, int page, int pageSize);
+
+        [Post("/content/filter?page={page}&pageSize={pageSize}&hyperlinks=false")]
+        Task<Delivery.Models.PagedContent<T>> Filter([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, [Body] ContentFilter filter, int page, int pageSize);
     }
 
     [Headers(Constants.ApiVersionHeader)]

--- a/src/Umbraco.Headless.Client.Net/Delivery/IContentDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/IContentDelivery.cs
@@ -172,6 +172,17 @@ namespace Umbraco.Headless.Client.Net.Delivery
         Task<PagedContent> Filter(ContentFilter filter, string culture = null, int page = 1, int pageSize = 10);
 
         /// <summary>
+        /// Filter content based on property value and optionally content type
+        /// </summary>
+        /// <typeparam name="T">A type that inherits from the <see cref="IContent"/> interface</typeparam>
+        /// <param name="filter"><see cref="ContentFilter"/> with at least one property</param>
+        /// <param name="culture">Content Culture (Optional)</param>
+        /// <param name="page">Integer specifying the page number (Optional)</param>
+        /// <param name="pageSize">Integer specifying the page size (Optional)</param>
+        /// <returns></returns>
+        Task<PagedContent<T>> Filter<T>(ContentFilter filter, string culture = null, int page = 1, int pageSize = 10) where T : IContent;
+
+        /// <summary>
         /// Search for content by term
         /// </summary>
         /// <param name="term">Search term</param>

--- a/src/Umbraco.Headless.Client.Net/Delivery/Models/ContentFilter.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/Models/ContentFilter.cs
@@ -13,7 +13,7 @@
             Properties = properties;
         }
 
-        public string ContentTypeAlias { get; }
+        public string ContentTypeAlias { get; internal set; }
         public ContentFilterProperties[] Properties { get; }
 
     }

--- a/test/Umbraco.Headless.Client.Net.Tests/ContentDeliveryJson.Designer.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/ContentDeliveryJson.Designer.cs
@@ -288,6 +288,12 @@ namespace Umbraco.Headless.Client.Net.Tests {
             }
         }
 
+        internal static string Filter {
+            get {
+                return ResourceManager.GetString("Filter", resourceCulture);
+            }
+        }
+
         internal static string Search {
             get {
                 return ResourceManager.GetString("Search", resourceCulture);

--- a/test/Umbraco.Headless.Client.Net.Tests/ContentDeliveryJson.resx
+++ b/test/Umbraco.Headless.Client.Net.Tests/ContentDeliveryJson.resx
@@ -5306,7 +5306,116 @@
   }
 }</value>
   </data>
-  <data name="Search" xml:space="preserve">
+
+  <data name="Filter" xml:space="preserve">
+    <value>{
+  "_totalItems": 1,
+  "_totalPages": 1,
+  "_page": 1,
+  "_pageSize": 10,
+  "_links": {
+    "self": {
+        "href": "https://cdn.umbraco.io/content/filter?page=1&amp;pageSize=10"
+    },
+    "page": {
+        "href": "https://cdn.umbraco.io/content/filter{?page,pageSize}",
+        "templated": true
+    },
+    "root": {
+        "href": "https://cdn.umbraco.io/content{?contentType}",
+        "templated": true
+    },
+  },
+  "_embedded": {
+    "content": [
+      {
+        "_creatorName": "Rasmus",
+        "_url": "/products/biker-jacket/",
+        "_writerName": "Rasmus",
+        "_hasChildren": false,
+        "_level": 2,
+        "_createDate": "2019-06-17T13:46:24.497Z",
+        "_id": "262beb70-53a6-49b8-9e98-cfde2e85a78e",
+        "_updateDate": "2019-09-16T11:25:44.433Z",
+        "_links": {
+          "self": {
+            "href": "/cdn/content/262beb70-53a6-49b8-9e98-cfde2e85a78e"
+          },
+          "photos": {
+            "href": "/cdn/media/55514845-b8bd-487c-b370-9724852fd6bb",
+            "title": "Biker Jacket"
+          },
+          "root": {
+            "href": "/cdn/content"
+          },
+          "children": {
+            "href": "/cdn/content/262beb70-53a6-49b8-9e98-cfde2e85a78e/children"
+          },
+          "ancestors": {
+            "href": "/cdn/content/262beb70-53a6-49b8-9e98-cfde2e85a78e/ancestors"
+          },
+          "descendants": {
+            "href": "/cdn/content/262beb70-53a6-49b8-9e98-cfde2e85a78e/descendants"
+          },
+          "parent": {
+            "href": "/cdn/content/ec4aafcc-0c25-4f25-a8fe-705bfae1d324"
+          }
+        },
+        "contentTypeAlias": "product",
+        "name": "Biker Jacket",
+        "parentId": "ec4aafcc-0c25-4f25-a8fe-705bfae1d324",
+        "sortOrder": 7,
+        "productName": "Biker Jacket",
+        "price": 199.0,
+        "description": "Donec rutrum congue leo eget malesuada. Vivamus suscipit tortor eget felis porttitor volutpat.",
+        "sku": "UMB-BIKER-JACKET",
+        "photos": {
+          "_creatorName": "Rasmus",
+          "_url": "/media/55514845b8bd487cb3709724852fd6bb/00000006000000000000000000000000/4730684907_8a7f8759cb_b.jpg",
+          "_writerName": "Rasmus",
+          "_hasChildren": false,
+          "_level": 2,
+          "_createDate": "2019-06-17T13:46:42.377Z",
+          "_id": "55514845-b8bd-487c-b370-9724852fd6bb",
+          "_updateDate": "2019-06-17T13:46:42.377Z",
+          "_links": null,
+          "mediaTypeAlias": "Image",
+          "name": "Biker Jacket",
+          "parentId": "6d5bf746-cb82-45c5-bd15-dd3798209b87",
+          "sortOrder": 0,
+          "umbracoFile": {
+            "src": "/media/55514845b8bd487cb3709724852fd6bb/00000006000000000000000000000000/4730684907_8a7f8759cb_b.jpg",
+            "focalPoint": null,
+            "crops": null
+          },
+          "umbracoWidth": 680,
+          "umbracoHeight": 1024,
+          "umbracoBytes": 224349,
+          "umbracoExtension": "jpg"
+        },
+        "features": [
+          {
+            "contentTypeAlias": "feature",
+            "featureName": "Free shipping",
+            "featureDetails": "Isn't that awesome - you only pay for the product"
+          },
+          {
+            "contentTypeAlias": "feature",
+            "featureName": "1 Day return policy",
+            "featureDetails": "You'll need to make up your mind fast"
+          },
+          {
+            "contentTypeAlias": "feature",
+            "featureName": "100 Years warranty",
+            "featureDetails": "But if you're satisfied it'll last a lifetime"
+          }
+        ]
+      }
+    ]
+  }
+}</value>
+  </data>
+<data name="Search" xml:space="preserve">
     <value>{
   "_totalItems": 1,
   "_totalPages": 1,

--- a/test/Umbraco.Headless.Client.Net.Tests/TypedContentDeliveryFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/TypedContentDeliveryFixture.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using RichardSzalay.MockHttp;
 using Umbraco.Headless.Client.Net.Configuration;
 using Umbraco.Headless.Client.Net.Delivery;
+using Umbraco.Headless.Client.Net.Delivery.Models;
 using Umbraco.Headless.Client.Net.Tests.StronglyTypedModels;
 using Xunit;
 
@@ -84,6 +86,28 @@ namespace Umbraco.Headless.Client.Net.Tests
             Assert.NotEmpty(pagedContent.Content.Items);
             Assert.Equal(1, pagedContent.TotalPages);
             Assert.Equal(8, pagedContent.TotalItems);
+            foreach (var contentItem in pagedContent.Content.Items)
+            {
+                Assert.NotNull(contentItem);
+                Assert.False(string.IsNullOrEmpty(contentItem.ProductName));
+            }
+        }
+
+        [Theory]
+        [InlineData("description", "Donec", ContentFilterMatch.Contains)]
+        public async Task Can_Retrieve_Filtered_Content_As_Typed_Object(string alias, string value, ContentFilterMatch match)
+        {
+            var service = new ContentDeliveryService(_configuration, GetMockedHttpClient($"{_contentBaseUrl}/filter", ContentDeliveryJson.Filter));
+            var filters = new List<ContentFilterProperties>();
+            filters.Add(new ContentFilterProperties(alias, value, match));
+            var contentFilter = new ContentFilter(filters.ToArray());
+            var pagedContent = await service.Content.Filter<Product>(contentFilter);
+
+            Assert.NotNull(pagedContent);
+            Assert.NotNull(pagedContent.Content);
+            Assert.NotEmpty(pagedContent.Content.Items);
+            Assert.Equal(1, pagedContent.TotalPages);
+            Assert.Equal(1, pagedContent.TotalItems);
             foreach (var contentItem in pagedContent.Content.Items)
             {
                 Assert.NotNull(contentItem);


### PR DESCRIPTION
Added support for getting results from `/content/filter/` as anything derived from `IContent`.

### Usage:
```c#
var filters = new List<ContentFilterProperties> {
    new ContentFilterProperties(alias, value, match))
};
var contentFilter = new ContentFilter(filters.ToArray());
var pagedContent = await service.Content.Filter<Product>(contentFilter);

var productNames = pagedContent.Content?.Items.Select(x => x.ProductName);
```