### PR TITLE
Fix: Filter Match type is not serialized to string

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Delivery/Models/ContentFilter.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/Models/ContentFilter.cs
@@ -1,4 +1,7 @@
-﻿namespace Umbraco.Headless.Client.Net.Delivery.Models
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Umbraco.Headless.Client.Net.Delivery.Models
 {
     public class ContentFilter
     {
@@ -29,6 +32,8 @@
 
         public string Alias { get; }
         public string Value { get; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
         public ContentFilterMatch Match { get; }
     }
 


### PR DESCRIPTION
When using `ContentDelivery.Filter()` the `ContentFilterProperties` property `Match` (which is an `enum`) was not serialized to a string, causing the Refit-request to send requests similar to 
```application/json
{
    "ContentTypeAlias": "product",
    "Properties":[
        {
            "Alias": "nodeName",
            "Value": "Lorem",
            "Match": "0"
        }
     ]
}
```

This is resolved by adding the attribute `[JsonConverter(typeof(StringEnumConverter))]`