### PR TITLE
added version header to Filter<T> ContentDeliveryEndpoint

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
@@ -59,6 +59,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         [Get("/content/type?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
         Task<Delivery.Models.PagedContent<T>> GetByType([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType, int page, int pageSize);
 
+        [Headers(Constants.ApiVersionHeader)]
         [Post("/content/filter?page={page}&pageSize={pageSize}&hyperlinks=false")]
         Task<Delivery.Models.PagedContent<T>> Filter([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, [Body] ContentFilter filter, int page, int pageSize);
     }


### PR DESCRIPTION
Added missing header attribute, causing Filter<T> to fail as it sends Header for 2.0 instead of 2.1