### PR TITLE
Fixes violation of static code analysis rule CA2007

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         public async Task<IEnumerable<Content>> GetRoot(string culture)
         {
             var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var root = await service.GetRoot(_configuration.ProjectAlias, culture);
+            var root = await service.GetRoot(_configuration.ProjectAlias, culture).ConfigureAwait(false);
             return root.Content.Items;
         }
 
@@ -31,14 +31,14 @@ namespace Umbraco.Headless.Client.Net.Delivery
             var contentType = GetAliasFromClassName<T>();
 
             var service = RestService.For<TypedContentRootDeliveryEndpoints<T>>(_httpClient);
-            var root = await service.GetRoot(_configuration.ProjectAlias, culture, contentType);
+            var root = await service.GetRoot(_configuration.ProjectAlias, culture, contentType).ConfigureAwait(false);
             return root.Content.Items;
         }
 
         public async Task<Content> GetById(Guid id, string culture, int depth)
         {
             var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var content = await service.GetById(_configuration.ProjectAlias, culture, id, depth);
+            var content = await service.GetById(_configuration.ProjectAlias, culture, id, depth).ConfigureAwait(false);
             return content;
         }
 
@@ -47,14 +47,14 @@ namespace Umbraco.Headless.Client.Net.Delivery
             var contentType = GetAliasFromClassName<T>();
 
             var service = RestService.For<TypedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetById(_configuration.ProjectAlias, culture, id, contentType, depth);
+            var content = await service.GetById(_configuration.ProjectAlias, culture, id, contentType, depth).ConfigureAwait(false);
             return content;
         }
 
         public async Task<Content> GetByUrl(string url, string culture, int depth)
         {
             var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var content = await service.GetByUrl(_configuration.ProjectAlias, culture, url, depth);
+            var content = await service.GetByUrl(_configuration.ProjectAlias, culture, url, depth).ConfigureAwait(false);
             return content;
         }
 
@@ -63,14 +63,14 @@ namespace Umbraco.Headless.Client.Net.Delivery
             var contentType = GetAliasFromClassName<T>();
 
             var service = RestService.For<TypedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetByUrl(_configuration.ProjectAlias, culture, url, contentType, depth);
+            var content = await service.GetByUrl(_configuration.ProjectAlias, culture, url, contentType, depth).ConfigureAwait(false);
             return content;
         }
 
         public async Task<PagedContent> GetChildren(Guid id, string culture, int page, int pageSize)
         {
             var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var content = await service.GetChildren(_configuration.ProjectAlias, culture, id, page, pageSize);
+            var content = await service.GetChildren(_configuration.ProjectAlias, culture, id, page, pageSize).ConfigureAwait(false);
             return content;
         }
 
@@ -79,14 +79,14 @@ namespace Umbraco.Headless.Client.Net.Delivery
             var contentType = GetAliasFromClassName<T>();
 
             var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetChildren(_configuration.ProjectAlias, culture, id, contentType, page, pageSize);
+            var content = await service.GetChildren(_configuration.ProjectAlias, culture, id, contentType, page, pageSize).ConfigureAwait(false);
             return content;
         }
 
         public async Task<PagedContent> GetDescendants(Guid id, string culture, int page, int pageSize)
         {
             var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var content = await service.GetDescendants(_configuration.ProjectAlias, culture, id, page, pageSize);
+            var content = await service.GetDescendants(_configuration.ProjectAlias, culture, id, page, pageSize).ConfigureAwait(false);
             return content;
         }
 
@@ -95,14 +95,14 @@ namespace Umbraco.Headless.Client.Net.Delivery
             var contentType = GetAliasFromClassName<T>();
 
             var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetDescendants(_configuration.ProjectAlias, culture, id, contentType, page, pageSize);
+            var content = await service.GetDescendants(_configuration.ProjectAlias, culture, id, contentType, page, pageSize).ConfigureAwait(false);
             return content;
         }
 
         public async Task<IEnumerable<Content>> GetAncestors(Guid id, string culture)
         {
             var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var root = await service.GetAncestors(_configuration.ProjectAlias, culture, id);
+            var root = await service.GetAncestors(_configuration.ProjectAlias, culture, id).ConfigureAwait(false);
             return root.Content.Items;
         }
 
@@ -111,27 +111,27 @@ namespace Umbraco.Headless.Client.Net.Delivery
             var contentType = GetAliasFromClassName<T>();
 
             var service = RestService.For<TypedContentRootDeliveryEndpoints<T>>(_httpClient);
-            var root = await service.GetAncestors(_configuration.ProjectAlias, culture, id, contentType);
+            var root = await service.GetAncestors(_configuration.ProjectAlias, culture, id, contentType).ConfigureAwait(false);
             return root.Content.Items;
         }
 
         public async Task<PagedContent> GetByType(string contentType, string culture = null, int page = 1, int pageSize = 10)
         {
             var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var content = await service.GetByType(_configuration.ProjectAlias, culture, contentType, page, pageSize);
+            var content = await service.GetByType(_configuration.ProjectAlias, culture, contentType, page, pageSize).ConfigureAwait(false);
             return content;
         }
 
         public async Task<PagedContent<T>> GetByType<T>(string culture = null, int page = 1, int pageSize = 10) where T : IContent
         {
             var contentType = GetAliasFromClassName<T>();
-            return await GetByTypeAlias<T>(contentType, culture, page, pageSize);
+            return await GetByTypeAlias<T>(contentType, culture, page, pageSize).ConfigureAwait(false);
         }
 
         public async Task<PagedContent<T>> GetByTypeAlias<T>(string contentTypeAlias, string culture = null, int page = 1, int pageSize = 10) where T : IContent
         {
             var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetByType(_configuration.ProjectAlias, culture, contentTypeAlias, page, pageSize);
+            var content = await service.GetByType(_configuration.ProjectAlias, culture, contentTypeAlias, page, pageSize).ConfigureAwait(false);
             return content;
         }
 
@@ -143,7 +143,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
             filter.ContentTypeAlias = filter.ContentTypeAlias ?? GetAliasFromClassName<T>();
 
             var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.Filter(_configuration.ProjectAlias, culture, filter, page, pageSize);
+            var content = await service.Filter(_configuration.ProjectAlias, culture, filter, page, pageSize).ConfigureAwait(false);
             return content;
         }
         public async Task<PagedContent> Filter(ContentFilter filter, string culture = null, int page = 1, int pageSize = 10)
@@ -152,14 +152,14 @@ namespace Umbraco.Headless.Client.Net.Delivery
                 throw new ArgumentException("ContentFilter should contain at least one property to filter on");
 
             var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var content = await service.Filter(_configuration.ProjectAlias, culture, filter, page, pageSize);
+            var content = await service.Filter(_configuration.ProjectAlias, culture, filter, page, pageSize).ConfigureAwait(false);
             return content;
         }
 
         public async Task<PagedContent> Search(string term, string culture = null, int page = 1, int pageSize = 10)
         {
             var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var content = await service.Search(_configuration.ProjectAlias, culture, term, page, pageSize);
+            var content = await service.Search(_configuration.ProjectAlias, culture, term, page, pageSize).ConfigureAwait(false);
             return content;
         }
 

--- a/src/Umbraco.Headless.Client.Net/Delivery/MediaDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/MediaDelivery.cs
@@ -22,42 +22,42 @@ namespace Umbraco.Headless.Client.Net.Delivery
         public async Task<IEnumerable<Media>> GetRoot()
         {
             var service = RestService.For<MediaDeliveryEndpoints>(_httpClient);
-            var root = await service.GetRoot(_configuration.ProjectAlias);
+            var root = await service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
             return root.Media.Items;
         }
 
         public async Task<IEnumerable<T>> GetRoot<T>() where T : IMedia
         {
             var service = RestService.For<TypedMediaDeliveryEndpoints<T>>(_httpClient);
-            var root = await service.GetRoot(_configuration.ProjectAlias);
+            var root = await service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
             return root.Media.Items;
         }
 
         public async Task<Media> GetById(Guid id)
         {
             var service = RestService.For<MediaDeliveryEndpoints>(_httpClient);
-            var content = await service.GetById(_configuration.ProjectAlias, id);
+            var content = await service.GetById(_configuration.ProjectAlias, id).ConfigureAwait(false);
             return content;
         }
 
         public async Task<T> GetById<T>(Guid id) where T : IMedia
         {
             var service = RestService.For<TypedMediaDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetById(_configuration.ProjectAlias, id);
+            var content = await service.GetById(_configuration.ProjectAlias, id).ConfigureAwait(false);
             return content;
         }
 
         public async Task<PagedMedia> GetChildren(Guid id, int page = 0, int pageSize = 10)
         {
             var service = RestService.For<MediaDeliveryEndpoints>(_httpClient);
-            var content = await service.GetChildren(_configuration.ProjectAlias, id, page, pageSize);
+            var content = await service.GetChildren(_configuration.ProjectAlias, id, page, pageSize).ConfigureAwait(false);
             return content;
         }
 
         public async Task<PagedMedia<T>> GetChildren<T>(Guid id, int page = 0, int pageSize = 10) where T : IMedia
         {
             var service = RestService.For<TypedMediaDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetChildren(_configuration.ProjectAlias, id, page, pageSize);
+            var content = await service.GetChildren(_configuration.ProjectAlias, id, page, pageSize).ConfigureAwait(false);
             return content;
         }
     }

--- a/src/Umbraco.Headless.Client.Net/Management/ContentService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/ContentService.cs
@@ -45,7 +45,7 @@ namespace Umbraco.Headless.Client.Net.Management
 
         public async Task<IEnumerable<Content>> GetRoot()
         {
-            var content = await Service.GetRoot(_configuration.ProjectAlias);
+            var content = await Service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
             return content.Content.Items;
         }
 

--- a/src/Umbraco.Headless.Client.Net/Management/DocumentTypeService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/DocumentTypeService.cs
@@ -28,11 +28,11 @@ namespace Umbraco.Headless.Client.Net.Management
 
         public async Task<IEnumerable<DocumentType>> GetAll()
         {
-            var root = await Service.GetRoot(_configuration.ProjectAlias);
+            var root = await Service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
             return root.DocumentTypes.Items;
         }
 
         public async Task<DocumentType> GetByAlias(string alias) =>
-            await Service.ByAlias(_configuration.ProjectAlias, alias);
+            await Service.ByAlias(_configuration.ProjectAlias, alias).ConfigureAwait(false);
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Management/FormService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/FormService.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Headless.Client.Net.Management
 
         public async Task<IEnumerable<Form>> GetAll()
         {
-            var forms = await Service.GetRoot(_configuration.ProjectAlias);
+            var forms = await Service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
             return forms.Forms.Items;
         }
 

--- a/src/Umbraco.Headless.Client.Net/Management/HttpClientExtensions.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/HttpClientExtensions.cs
@@ -10,19 +10,19 @@ namespace Umbraco.Headless.Client.Net.Management
         public static async Task<T> PostMultipartAsync<T>(this HttpClient client, IContentSerializer contentSerializer,
             string url, string projectAlias, object data, IDictionary<string, MultipartItem> files)
         {
-            var content = await CreateContent<T>(contentSerializer, projectAlias, data, files);
+            var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false);
 
-            var response = await client.PostAsync(url, content);
-            return await contentSerializer.DeserializeAsync<T>(response.Content);
+            var response = await client.PostAsync(url, content).ConfigureAwait(false);
+            return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
         }
 
         public static async Task<T> PutMultipartAsync<T>(this HttpClient client, IContentSerializer contentSerializer,
             string url, string projectAlias, object data, IDictionary<string, MultipartItem> files)
         {
-            var content = await CreateContent<T>(contentSerializer, projectAlias, data, files);
+            var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false);
 
-            var response = await client.PutAsync(url, content);
-            return await contentSerializer.DeserializeAsync<T>(response.Content);
+            var response = await client.PutAsync(url, content).ConfigureAwait(false);
+            return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
         }
 
         private static async Task<MultipartFormDataContent> CreateContent<T>(IContentSerializer contentSerializer, string projectAlias, object data,
@@ -35,7 +35,7 @@ namespace Umbraco.Headless.Client.Net.Management
                     {Constants.Headers.ProjectAlias, projectAlias}
                 },
             };
-            var postData = await contentSerializer.SerializeAsync(data);
+            var postData = await contentSerializer.SerializeAsync(data).ConfigureAwait(false);
             content.Add(postData, "content");
             foreach (var file in files)
                 content.Add(file.Value.ToContent(), file.Key, file.Value.FileName);

--- a/src/Umbraco.Headless.Client.Net/Management/LanguageService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/LanguageService.cs
@@ -28,20 +28,20 @@ namespace Umbraco.Headless.Client.Net.Management
 
         public async Task<IEnumerable<Language>> GetAll()
         {
-            var languages = await Service.GetRoot(_headlessConfiguration.ProjectAlias);
+            var languages = await Service.GetRoot(_headlessConfiguration.ProjectAlias).ConfigureAwait(false);
             return languages.Languages.Items;
         }
 
         public async Task<Language> GetByIsoCode(string isoCode)
-            => await Service.ByIsoCode(_headlessConfiguration.ProjectAlias, isoCode);
+            => await Service.ByIsoCode(_headlessConfiguration.ProjectAlias, isoCode).ConfigureAwait(false);
 
         public async Task<Language> Create(Language language)
-            => await Service.Create(_headlessConfiguration.ProjectAlias, language);
+            => await Service.Create(_headlessConfiguration.ProjectAlias, language).ConfigureAwait(false);
 
         public async Task<Language> Update(string isoCode, Language language)
-            => await Service.Update(_headlessConfiguration.ProjectAlias, isoCode, language);
+            => await Service.Update(_headlessConfiguration.ProjectAlias, isoCode, language).ConfigureAwait(false);
 
         public async Task<Language> Delete(string isoCode)
-            => await Service.Delete(_headlessConfiguration.ProjectAlias, isoCode);
+            => await Service.Delete(_headlessConfiguration.ProjectAlias, isoCode).ConfigureAwait(false);
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Management/MediaService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/MediaService.cs
@@ -45,7 +45,7 @@ namespace Umbraco.Headless.Client.Net.Management
 
         public async Task<IEnumerable<Media>> GetRoot()
         {
-            var media = await Service.GetRoot(_configuration.ProjectAlias);
+            var media = await Service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
             return media.Media.Items;
         }
 

--- a/src/Umbraco.Headless.Client.Net/Management/MediaTypeService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/MediaTypeService.cs
@@ -28,11 +28,11 @@ namespace Umbraco.Headless.Client.Net.Management
 
         public async Task<IEnumerable<MediaType>> GetAll()
         {
-            var root = await Service.GetRoot(_configuration.ProjectAlias);
+            var root = await Service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
             return root.MediaTypes.Items;
         }
 
         public async Task<MediaType> GetByAlias(string alias) =>
-            await Service.ByAlias(_configuration.ProjectAlias, alias);
+            await Service.ByAlias(_configuration.ProjectAlias, alias).ConfigureAwait(false);
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Management/MemberGroupService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/MemberGroupService.cs
@@ -28,17 +28,17 @@ namespace Umbraco.Headless.Client.Net.Management
 
         public async Task<IEnumerable<MemberGroup>> GetAll()
         {
-            var result = await Service.GetAll(_headlessConfiguration.ProjectAlias);
+            var result = await Service.GetAll(_headlessConfiguration.ProjectAlias).ConfigureAwait(false);
             return result.MemberGroups.Items;
         }
 
         public async Task<MemberGroup> GetByName(string name)
-            => await Service.GetByName(_headlessConfiguration.ProjectAlias, name);
+            => await Service.GetByName(_headlessConfiguration.ProjectAlias, name).ConfigureAwait(false);
 
         public async Task<MemberGroup> Create(MemberGroup memberGroup)
-            => await Service.Create(_headlessConfiguration.ProjectAlias, memberGroup);
+            => await Service.Create(_headlessConfiguration.ProjectAlias, memberGroup).ConfigureAwait(false);
 
         public async Task<MemberGroup> Delete(string name)
-            => await Service.GetByName(_headlessConfiguration.ProjectAlias, name);
+            => await Service.GetByName(_headlessConfiguration.ProjectAlias, name).ConfigureAwait(false);
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Management/MemberTypeService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/MemberTypeService.cs
@@ -28,11 +28,11 @@ namespace Umbraco.Headless.Client.Net.Management
 
         public async Task<IEnumerable<MemberType>> GetAll()
         {
-            var root = await Service.GetRoot(_configuration.ProjectAlias);
+            var root = await Service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
             return root.MemberTypes.Items;
         }
 
         public async Task<MemberType> GetByAlias(string alias) =>
-            await Service.ByAlias(_configuration.ProjectAlias, alias);
+            await Service.ByAlias(_configuration.ProjectAlias, alias).ConfigureAwait(false);
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Management/RelationService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/RelationService.cs
@@ -26,28 +26,28 @@ namespace Umbraco.Headless.Client.Net.Management
             _restService ?? (_restService = RestService.For<RelationManagementEndpoints>(_httpClient, _refitSettings));
 
         public async Task<Relation> Create(Relation relation) =>
-            await Service.Create(_configuration.ProjectAlias, relation);
+            await Service.Create(_configuration.ProjectAlias, relation).ConfigureAwait(false);
 
-        public async Task<Relation> Delete(int id) => await Service.Delete(_configuration.ProjectAlias, id);
+        public async Task<Relation> Delete(int id) => await Service.Delete(_configuration.ProjectAlias, id).ConfigureAwait(false);
 
 
         public async Task<IEnumerable<Relation>> GetByAlias(string alias)
         {
-            var collection = await Service.ByAlias(_configuration.ProjectAlias, alias);
+            var collection = await Service.ByAlias(_configuration.ProjectAlias, alias).ConfigureAwait(false);
             return collection.Relations.Items;
         }
 
         public async Task<IEnumerable<Relation>> GetByChildId(Guid childId)
         {
-            var collection = await Service.ByChildId(_configuration.ProjectAlias, childId);
+            var collection = await Service.ByChildId(_configuration.ProjectAlias, childId).ConfigureAwait(false);
             return collection.Relations.Items;
         }
 
-        public async Task<Relation> GetById(int id) => await Service.ById(_configuration.ProjectAlias, id);
+        public async Task<Relation> GetById(int id) => await Service.ById(_configuration.ProjectAlias, id).ConfigureAwait(false);
 
         public async Task<IEnumerable<Relation>> ByParentId(Guid parentId)
         {
-            var collection = await Service.ByParentId(_configuration.ProjectAlias, parentId);
+            var collection = await Service.ByParentId(_configuration.ProjectAlias, parentId).ConfigureAwait(false);
             return collection.Relations.Items;
         }
     }

--- a/src/Umbraco.Headless.Client.Net/Management/RelationTypeService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/RelationTypeService.cs
@@ -28,11 +28,11 @@ namespace Umbraco.Headless.Client.Net.Management
 
         public async Task<IEnumerable<RelationType>> GetAll()
         {
-            var root = await Service.GetRoot(_configuration.ProjectAlias);
+            var root = await Service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
             return root.RelationTypes.Items;
         }
 
         public async Task<RelationType> GetByAlias(string alias) =>
-            await Service.ByAlias(_configuration.ProjectAlias, alias);
+            await Service.ByAlias(_configuration.ProjectAlias, alias).ConfigureAwait(false);
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Security/AuthenticatedHttpClientHandler.cs
+++ b/src/Umbraco.Headless.Client.Net/Security/AuthenticatedHttpClientHandler.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Headless.Client.Net.Security
         {
             if (!string.IsNullOrEmpty(_token) && DateTime.UtcNow < _tokenExpirationTime)
             {
-                return await Task.FromResult(_token);
+                return await Task.FromResult(_token).ConfigureAwait(false);
             }
 
             var formData = new Dictionary<string, string>
@@ -52,7 +52,7 @@ namespace Umbraco.Headless.Client.Net.Security
             };
 
             var response = await RestService.For<OAuthEndpoints>(Constants.Urls.BaseApiUrl)
-                .GetAuthToken(_configuration.ProjectAlias, formData);
+                .GetAuthToken(_configuration.ProjectAlias, formData).ConfigureAwait(false);
 
             _token = response.AccessToken;
             _tokenExpirationTime = DateTime.UtcNow

--- a/src/Umbraco.Headless.Client.Net/Umbraco.Headless.Client.Net.csproj
+++ b/src/Umbraco.Headless.Client.Net/Umbraco.Headless.Client.Net.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="refit" Version="4.7.51" />
+     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
As this is library code that is agnostic to the app model it might be used in, ConfigureAwait(false) should be used.

More info about the rule here: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2007?view=vs-2019

More info about ConfigureAwait (a deep dive) here: https://devblogs.microsoft.com/dotnet/configureawait-faq/
