### PR TITLE
Implements a service to use for accessing the Preview API.

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryService.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryService.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
     /// <summary>
     /// Service class for interacting with the Content Delivery API
     /// </summary>
-    public class ContentDeliveryService
+    public class ContentDeliveryService : IContentDeliveryService
     {
         /// <summary>
         /// Initializes a new instance of the ContentDeliveryService class

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentPreviewService.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentPreviewService.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Net.Http;
+using Umbraco.Headless.Client.Net.Configuration;
+
+namespace Umbraco.Headless.Client.Net.Delivery
+{
+    /// <summary>
+    /// Service class for interacting with the Preview API.
+    /// The Preview API retrieves drafts of what is available in the Content Delivery API.
+    /// </summary>
+    public class ContentPreviewService : IContentDeliveryService
+    {
+        /// <summary>
+        /// Initializes a new instance of the ContentPreviewService class
+        /// </summary>
+        /// <param name="projectAlias">Alias of the Project</param>
+        /// <param name="apiKey">Api Key</param>
+        public ContentPreviewService(string projectAlias, string apiKey) : this(new ApiKeyBasedConfiguration(projectAlias, apiKey))
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the ContentPreviewService class
+        /// </summary>
+        /// <param name="configuration">Reference to the <see cref="IApiKeyBasedConfiguration"/></param>
+        public ContentPreviewService(IApiKeyBasedConfiguration configuration)
+        {
+            var httpClient = new HttpClient
+            {
+                BaseAddress = new Uri(Constants.Urls.BasePreviewUrl),
+                DefaultRequestHeaders = { { Constants.Headers.ApiKey, configuration.Token } }
+            };
+
+            Content = new ContentDelivery(configuration, httpClient);
+            Media = new MediaDelivery(configuration, httpClient);
+        }
+
+        /// <summary>
+        /// Gets the Content part of the Preview API
+        /// </summary>
+        public IContentDelivery Content { get; }
+
+        /// <summary>
+        /// Gets the Media part of the Preview API
+        /// </summary>
+        public IMediaDelivery Media { get; }
+    }
+}

--- a/src/Umbraco.Headless.Client.Net/Delivery/IContentDeliveryService.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/IContentDeliveryService.cs
@@ -1,0 +1,15 @@
+﻿namespace Umbraco.Headless.Client.Net.Delivery
+{
+    public interface IContentDeliveryService
+    {
+        /// <summary>
+        /// Gets the Content part of the Content Delivery API
+        /// </summary>
+        IContentDelivery Content { get; }
+
+        /// <summary>
+        /// Gets the Media part of the Content Delivery API
+        /// </summary>
+        IMediaDelivery Media { get; }
+    }
+}


### PR DESCRIPTION
Introduces an interface for Content Delivery and Preview as the two should be interchangable.

I created a new Service as I wanted to enforce the use of API Keys through the constructor and not add yet another option in the constructor of the Content Delivery API. With the `IContentDeliveryService` in place it should be possible to easily switch between using the Content Delivery API and the Preview API - the Content and Media parts are the same between the two services.