### PR TITLE
Add custom api exception error handling

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Configuration/ApiExceptionContext.cs
+++ b/src/Umbraco.Headless.Client.Net/Configuration/ApiExceptionContext.cs
@@ -1,0 +1,21 @@
+using Refit;
+
+namespace Umbraco.Headless.Client.Net.Configuration
+{
+    /// <summary>
+    /// Contextual information about the API exception.
+    /// </summary>
+    public class ApiExceptionContext
+    {
+        /// <summary>
+        /// The exception.
+        /// </summary>
+        public ApiException Exception { get; set; }
+
+        /// <summary>
+        /// Determines if the exception should be thrown or not.
+        /// If <c>true</c> the exception will not be thrown, otherwise it will.
+        /// </summary>
+        public bool IsExceptionHandled { get; set; }
+    }
+}

--- a/src/Umbraco.Headless.Client.Net/Configuration/HeadlessConfiguration.cs
+++ b/src/Umbraco.Headless.Client.Net/Configuration/HeadlessConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using Umbraco.Headless.Client.Net.Collections;
 using Umbraco.Headless.Client.Net.Delivery.Models;
 
@@ -19,9 +20,26 @@ namespace Umbraco.Headless.Client.Net.Configuration
             };
         }
 
+        /// <inheritdoc />>
         public string ProjectAlias { get; }
+
+        /// <inheritdoc />>
         public ITypeList<IElement> ElementModelTypes { get; }
+
+        /// <inheritdoc />>
         public ITypeList<IContent> ContentModelTypes { get; }
+
+        /// <inheritdoc />>
         public ITypeList<IMedia> MediaModelTypes { get; }
+
+        /// <summary>
+        /// A delegate that is called if the APIs return a non success error code.
+        /// Can be used to handle, log or modify the exception before it is thrown.
+        /// The default sets <see cref="ApiExceptionContext.IsExceptionHandled"/> to <c>true</c> for not found requests.
+        /// </summary>
+        public Action<ApiExceptionContext> ApiExceptionDelegate { get; set; } = context =>
+        {
+            context.IsExceptionHandled = context.Exception.StatusCode == HttpStatusCode.NotFound;
+        };
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Configuration/HeadlessConfigurationExtensions.cs
+++ b/src/Umbraco.Headless.Client.Net/Configuration/HeadlessConfigurationExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Newtonsoft.Json;
 using Umbraco.Headless.Client.Net.Delivery;
@@ -30,7 +31,7 @@ namespace Umbraco.Headless.Client.Net.Configuration
                 };
             }
 
-            return new JsonConverter[0];
+            return Array.Empty<JsonConverter>();
         }
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Configuration/IHeadlessConfiguration.cs
+++ b/src/Umbraco.Headless.Client.Net/Configuration/IHeadlessConfiguration.cs
@@ -2,6 +2,9 @@
 {
     public interface IHeadlessConfiguration
     {
+        /// <summary>
+        /// The project alias.
+        /// </summary>
         string ProjectAlias { get; }
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Configuration/IStronglyTypedHeadlessConfiguration.cs
+++ b/src/Umbraco.Headless.Client.Net/Configuration/IStronglyTypedHeadlessConfiguration.cs
@@ -5,8 +5,19 @@ namespace Umbraco.Headless.Client.Net.Configuration
 {
     public interface IStronglyTypedHeadlessConfiguration : IHeadlessConfiguration
     {
+        /// <summary>
+        /// A list of strongly typed Element Type models,
+        /// </summary>
         ITypeList<IElement> ElementModelTypes { get; }
+
+        /// <summary>
+        /// A list of strongly typed Content Type models,
+        /// </summary>
         ITypeList<IContent> ContentModelTypes { get; }
+
+        /// <summary>
+        /// A list of strongly typed Media Type models,
+        /// </summary>
         ITypeList<IMedia> MediaModelTypes { get; }
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
@@ -1,134 +1,119 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Refit;
-using Umbraco.Headless.Client.Net.Collections;
 using Umbraco.Headless.Client.Net.Configuration;
 using Umbraco.Headless.Client.Net.Delivery.Models;
 
 namespace Umbraco.Headless.Client.Net.Delivery
 {
-    internal class ContentDelivery : IContentDelivery
+    internal class ContentDelivery : DeliveryBase, IContentDelivery
     {
-        private readonly IHeadlessConfiguration _configuration;
         private readonly HttpClient _httpClient;
+        private readonly RefitSettings _refitSettings;
         private readonly ModelNameResolver _modelNameResolver;
         private ContentDeliveryEndpoints _service;
 
-        public ContentDelivery(IHeadlessConfiguration configuration, HttpClient httpClient, ModelNameResolver modelNameResolver)
+        public ContentDelivery(IHeadlessConfiguration configuration, HttpClient httpClient, RefitSettings refitSettings, ModelNameResolver modelNameResolver) : base(configuration)
         {
-            _configuration = configuration;
             _httpClient = httpClient;
+            _refitSettings = refitSettings;
             _modelNameResolver = modelNameResolver;
         }
 
         private ContentDeliveryEndpoints Service =>
-            _service ?? (_service = RestService.For<ContentDeliveryEndpoints>(_httpClient,
-                new RefitSettings
-                {
-                    ContentSerializer = new JsonContentSerializer(new JsonSerializerSettings
-                    {
-                        Converters = _configuration.GetJsonConverters(_modelNameResolver)
-                    })
-                }));
+            _service ?? (_service = RestService.For<ContentDeliveryEndpoints>(_httpClient, _refitSettings));
 
         public async Task<IEnumerable<Content>> GetRoot(string culture)
         {
-            var root = await Service.GetRoot(_configuration.ProjectAlias, culture).ConfigureAwait(false);
-            return root.Content.Items;
+            var result = await Get(x => x.GetRoot(Configuration.ProjectAlias, culture)).ConfigureAwait(false);
+
+            return result?.Content.Items;
         }
 
         public async Task<IEnumerable<T>> GetRoot<T>(string culture) where T : IContent
         {
             var contentType = GetAliasFromClassName<T>();
 
-            var service = RestService.For<TypedContentRootDeliveryEndpoints<T>>(_httpClient);
-            var root = await service.GetRoot(_configuration.ProjectAlias, culture, contentType).ConfigureAwait(false);
-            return root.Content.Items;
+            var result = await GetTyped<T>(x => x.GetRoot(Configuration.ProjectAlias, culture, contentType)).ConfigureAwait(false);
+            return result?.Content.Items;
         }
 
         public async Task<Content> GetById(Guid id, string culture, int depth)
         {
-            var content = await Service.GetById(_configuration.ProjectAlias, culture, id, depth).ConfigureAwait(false);
-            return content;
+            var result = await Get(x => x.GetById(Configuration.ProjectAlias, culture, id, depth)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<T> GetById<T>(Guid id, string culture, int depth) where T : IContent
         {
             var contentType = GetAliasFromClassName<T>();
 
-            var service = RestService.For<TypedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetById(_configuration.ProjectAlias, culture, id, contentType, depth).ConfigureAwait(false);
-            return content;
+            var result = await GetTyped<T>(x => x.GetById(Configuration.ProjectAlias, culture, id, contentType, depth)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<Content> GetByUrl(string url, string culture, int depth)
         {
-            var content = await Service.GetByUrl(_configuration.ProjectAlias, culture, url, depth).ConfigureAwait(false);
-            return content;
+            var result = await Get(x => x.GetByUrl(Configuration.ProjectAlias, culture, url, depth)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<T> GetByUrl<T>(string url, string culture, int depth) where T : IContent
         {
             var contentType = GetAliasFromClassName<T>();
 
-            var service = RestService.For<TypedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetByUrl(_configuration.ProjectAlias, culture, url, contentType, depth).ConfigureAwait(false);
-            return content;
+            var result = await GetTyped<T>(x => x.GetByUrl(Configuration.ProjectAlias, culture, url, contentType, depth)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<PagedContent> GetChildren(Guid id, string culture, int page, int pageSize)
         {
-            var content = await Service.GetChildren(_configuration.ProjectAlias, culture, id, page, pageSize).ConfigureAwait(false);
-            return content;
+            var result = await Get(x => x.GetChildren(Configuration.ProjectAlias, culture, id, page, pageSize)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<PagedContent<T>> GetChildren<T>(Guid id, string culture, int page, int pageSize) where T : IContent
         {
             var contentType = GetAliasFromClassName<T>();
 
-            var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetChildren(_configuration.ProjectAlias, culture, id, contentType, page, pageSize).ConfigureAwait(false);
-            return content;
+            var result = await GetTyped<T>(x => x.GetChildren(Configuration.ProjectAlias, culture, id, contentType, page, pageSize)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<PagedContent> GetDescendants(Guid id, string culture, int page, int pageSize)
         {
-            var content = await Service.GetDescendants(_configuration.ProjectAlias, culture, id, page, pageSize).ConfigureAwait(false);
-            return content;
+            var result = await Get(x => x.GetDescendants(Configuration.ProjectAlias, culture, id, page, pageSize)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<PagedContent<T>> GetDescendants<T>(Guid id, string culture, int page, int pageSize) where T : IContent
         {
             var contentType = GetAliasFromClassName<T>();
 
-            var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetDescendants(_configuration.ProjectAlias, culture, id, contentType, page, pageSize).ConfigureAwait(false);
-            return content;
+            var result = await GetTyped<T>(x => x.GetDescendants(Configuration.ProjectAlias, culture, id, contentType, page, pageSize)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<IEnumerable<Content>> GetAncestors(Guid id, string culture)
         {
-            var root = await Service.GetAncestors(_configuration.ProjectAlias, culture, id).ConfigureAwait(false);
-            return root.Content.Items;
+            var result = await Get(x => x.GetAncestors(Configuration.ProjectAlias, culture, id)).ConfigureAwait(false);
+            return result?.Content.Items;
         }
 
         public async Task<IEnumerable<T>> GetAncestors<T>(Guid id, string culture) where T : IContent
         {
             var contentType = GetAliasFromClassName<T>();
 
-            var service = RestService.For<TypedContentRootDeliveryEndpoints<T>>(_httpClient);
-            var root = await service.GetAncestors(_configuration.ProjectAlias, culture, id, contentType).ConfigureAwait(false);
-            return root.Content.Items;
+            var result = await GetTyped<T>(x => x.GetAncestors(Configuration.ProjectAlias, culture, id, contentType)).ConfigureAwait(false);
+            return result?.Content.Items;
         }
 
         public async Task<PagedContent> GetByType(string contentType, string culture = null, int page = 1, int pageSize = 10)
         {
-            var content = await Service.GetByType(_configuration.ProjectAlias, culture, contentType, page, pageSize).ConfigureAwait(false);
-            return content;
+            var result = await Get(x => x.GetByType(Configuration.ProjectAlias, culture, contentType, page, page)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<PagedContent<T>> GetByType<T>(string culture = null, int page = 1, int pageSize = 10) where T : IContent
@@ -139,9 +124,10 @@ namespace Umbraco.Headless.Client.Net.Delivery
 
         public async Task<PagedContent<T>> GetByTypeAlias<T>(string contentTypeAlias, string culture = null, int page = 1, int pageSize = 10) where T : IContent
         {
-            var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetByType(_configuration.ProjectAlias, culture, contentTypeAlias, page, pageSize).ConfigureAwait(false);
-            return content;
+            var contentType = GetAliasFromClassName<T>();
+
+            var result = await GetTyped<T>(x => x.GetByType(Configuration.ProjectAlias, culture, contentType, page, pageSize)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<PagedContent<T>> Filter<T>(ContentFilter filter, string culture = null, int page = 1, int pageSize = 10) where T : IContent
@@ -151,25 +137,53 @@ namespace Umbraco.Headless.Client.Net.Delivery
 
             filter.ContentTypeAlias = filter.ContentTypeAlias ?? GetAliasFromClassName<T>();
 
-            var service = RestService.For<TypedPagedContentDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.Filter(_configuration.ProjectAlias, culture, filter, page, pageSize).ConfigureAwait(false);
-            return content;
+            var result = await GetTyped<T>(x => x.Filter(Configuration.ProjectAlias, culture, filter, page, pageSize)).ConfigureAwait(false);
+            return result;
         }
+
         public async Task<PagedContent> Filter(ContentFilter filter, string culture = null, int page = 1, int pageSize = 10)
         {
             if(filter == null || filter.Properties.Length == 0)
                 throw new ArgumentException("ContentFilter should contain at least one property to filter on");
 
-            var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var content = await service.Filter(_configuration.ProjectAlias, culture, filter, page, pageSize).ConfigureAwait(false);
-            return content;
+            var result = await Get(x => x.Filter(Configuration.ProjectAlias, culture, filter, page, page)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<PagedContent> Search(string term, string culture = null, int page = 1, int pageSize = 10)
         {
-            var service = RestService.For<ContentDeliveryEndpoints>(_httpClient);
-            var content = await service.Search(_configuration.ProjectAlias, culture, term, page, pageSize).ConfigureAwait(false);
-            return content;
+            var result = await Get(x => x.Search(Configuration.ProjectAlias, culture, term, page, page)).ConfigureAwait(false);
+            return result;
+        }
+
+        private async Task<T> Get<T>(Func<ContentDeliveryEndpoints, Task<ApiResponse<T>>> getResponse)
+        {
+            using (var response = await getResponse(Service).ConfigureAwait(false))
+                return GetResponse(response);
+        }
+
+        private async Task<T> GetTyped<T>(Func<TypedContentDeliveryEndpoints<T>, Task<ApiResponse<T>>> getResponse) where T : IContent
+        {
+            var service = RestService.For<TypedContentDeliveryEndpoints<T>>(_httpClient);
+
+            using (var response = await getResponse(service).ConfigureAwait(false))
+                return GetResponse(response);
+        }
+
+        private async Task<RootContent<T>> GetTyped<T>(Func<TypedContentDeliveryEndpoints<T>, Task<ApiResponse<RootContent<T>>>> getResponse) where T : IContent
+        {
+            var service = RestService.For<TypedContentDeliveryEndpoints<T>>(_httpClient);
+
+            using (var response = await getResponse(service).ConfigureAwait(false))
+                return GetResponse(response);
+        }
+
+        private async Task<PagedContent<T>> GetTyped<T>(Func<TypedContentDeliveryEndpoints<T>, Task<ApiResponse<PagedContent<T>>>> getResponse) where T : IContent
+        {
+            var service = RestService.For<TypedContentDeliveryEndpoints<T>>(_httpClient);
+
+            using (var response = await getResponse(service).ConfigureAwait(false))
+                return GetResponse(response);
         }
 
         private string GetAliasFromClassName<T>() => _modelNameResolver.GetContentModelAlias(typeof(T));

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryEndpoints.cs
@@ -9,94 +9,86 @@ namespace Umbraco.Headless.Client.Net.Delivery
     interface ContentDeliveryEndpoints
     {
         [Get("/content?hyperlinks=false")]
-        Task<Delivery.Models.RootContent<Delivery.Models.Content>> GetRoot([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture);
+        Task<ApiResponse<Delivery.Models.RootContent<Delivery.Models.Content>>> GetRoot([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture);
 
         [Get("/content/{id}?depth={depth}")]
-        Task<Delivery.Models.Content> GetById([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, int depth);
+        Task<ApiResponse<Delivery.Models.Content>> GetById([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, int depth);
 
         [Get("/content/url?url={url}&depth={depth}&hyperlinks=false")]
-        Task<Delivery.Models.Content> GetByUrl([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string url, int depth);
+        Task<ApiResponse<Delivery.Models.Content>> GetByUrl([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string url, int depth);
 
         [Get("/content/{id}/ancestors?hyperlinks=false")]
-        Task<Delivery.Models.RootContent<Delivery.Models.Content>> GetAncestors([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id);
+        Task<ApiResponse<Delivery.Models.RootContent<Delivery.Models.Content>>> GetAncestors([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id);
 
         [Get("/content/{id}/children?page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedContent> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, int page, int pageSize);
+        Task<ApiResponse<Delivery.Models.PagedContent>> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, int page, int pageSize);
 
         [Get("/content/{id}/descendants?page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedContent> GetDescendants([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, int page, int pageSize);
+        Task<ApiResponse<Delivery.Models.PagedContent>> GetDescendants([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, int page, int pageSize);
 
         [Get("/content/type?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedContent> GetByType([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType, int page, int pageSize);
+        Task<ApiResponse<Delivery.Models.PagedContent>> GetByType([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType, int page, int pageSize);
 
         [Headers(Constants.Headers.ApiVersion + ":2.1")]
         [Post("/content/filter?page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedContent> Filter([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, [Body] ContentFilter filter, int page, int pageSize);
+        Task<ApiResponse<Delivery.Models.PagedContent>> Filter([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, [Body] ContentFilter filter, int page, int pageSize);
 
         [Get("/content/search?term={term}&page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedContent> Search([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string term, int page, int pageSize);
-    }
-
-    [Headers(Constants.ApiMinimumVersionHeader)]
-    interface TypedContentRootDeliveryEndpoints<T> where T : Delivery.Models.IContent
-    {
-        [Get("/content?contentType={contentType}&hyperlinks=false")]
-        Task<Delivery.Models.RootContent<T>> GetRoot([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType);
-
-        [Get("/content/{id}/ancestors?contentType={contentType}&hyperlinks=false")]
-        Task<Delivery.Models.RootContent<T>> GetAncestors([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType);
-    }
-
-    [Headers(Constants.ApiMinimumVersionHeader)]
-    interface TypedPagedContentDeliveryEndpoints<T> where T : Delivery.Models.IContent
-    {
-        [Get("/content/{id}/children?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedContent<T>> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType, int page, int pageSize);
-
-        [Get("/content/{id}/descendants?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedContent<T>> GetDescendants([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType, int page, int pageSize);
-
-        [Get("/content/type?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedContent<T>> GetByType([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType, int page, int pageSize);
-
-        [Headers(Constants.Headers.ApiVersion + ":2.1")]
-        [Post("/content/filter?page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedContent<T>> Filter([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, [Body] ContentFilter filter, int page, int pageSize);
+        Task<ApiResponse<Delivery.Models.PagedContent>> Search([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string term, int page, int pageSize);
     }
 
     [Headers(Constants.ApiMinimumVersionHeader)]
     interface TypedContentDeliveryEndpoints<T> where T : Delivery.Models.IContent
     {
+        [Get("/content?contentType={contentType}&hyperlinks=false")]
+        Task<ApiResponse<Delivery.Models.RootContent<T>>> GetRoot([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType);
+
+        [Get("/content/{id}/ancestors?contentType={contentType}&hyperlinks=false")]
+        Task<ApiResponse<Delivery.Models.RootContent<T>>> GetAncestors([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType);
+
+        [Get("/content/{id}/children?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
+        Task<ApiResponse<Delivery.Models.PagedContent<T>>> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType, int page, int pageSize);
+
+        [Get("/content/{id}/descendants?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
+        Task<ApiResponse<Delivery.Models.PagedContent<T>>> GetDescendants([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType, int page, int pageSize);
+
+        [Get("/content/type?contentType={contentType}&page={page}&pageSize={pageSize}&hyperlinks=false")]
+        Task<ApiResponse<Delivery.Models.PagedContent<T>>> GetByType([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string contentType, int page, int pageSize);
+
+        [Headers(Constants.Headers.ApiVersion + ":2.1")]
+        [Post("/content/filter?page={page}&pageSize={pageSize}&hyperlinks=false")]
+        Task<ApiResponse<Delivery.Models.PagedContent<T>>> Filter([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, [Body] ContentFilter filter, int page, int pageSize);
+
         [Get("/content/{id}?depth={depth}&contentType={contentType}&hyperlinks=false")]
-        Task<T> GetById([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType, int depth);
+        Task<ApiResponse<T>> GetById([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, Guid id, string contentType, int depth);
 
         [Get("/content/url?url={url}&depth={depth}&contentType={contentType}&hyperlinks=false")]
-        Task<T> GetByUrl([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string url, string contentType, int depth);
+        Task<ApiResponse<T>> GetByUrl([Header(Constants.Headers.ProjectAlias)] string projectAlias, [Header(Constants.Headers.AcceptLanguage)] string culture, string url, string contentType, int depth);
     }
 
     [Headers(Constants.ApiMinimumVersionHeader)]
     interface MediaDeliveryEndpoints
     {
         [Get("/media?hyperlinks=false")]
-        Task<Delivery.Models.RootMedia<Delivery.Models.Media>> GetRoot([Header(Constants.Headers.ProjectAlias)] string projectAlias);
+        Task<ApiResponse<Delivery.Models.RootMedia<Delivery.Models.Media>>> GetRoot([Header(Constants.Headers.ProjectAlias)] string projectAlias);
 
         [Get("/media/{id}?hyperlinks=false")]
-        Task<Delivery.Models.Media> GetById([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id);
+        Task<ApiResponse<Delivery.Models.Media>> GetById([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id);
 
         [Get("/media/{id}/children?page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedMedia> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, int page, int pageSize);
+        Task<ApiResponse<Delivery.Models.PagedMedia>> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, int page, int pageSize);
     }
 
     [Headers(Constants.ApiMinimumVersionHeader)]
     interface TypedMediaDeliveryEndpoints<T> where T : Delivery.Models.IMedia
     {
         [Get("/media?hyperlinks=false")]
-        Task<Delivery.Models.RootMedia<T>> GetRoot([Header(Constants.Headers.ProjectAlias)] string projectAlias);
+        Task<ApiResponse<Delivery.Models.RootMedia<T>>> GetRoot([Header(Constants.Headers.ProjectAlias)] string projectAlias);
 
         [Get("/media/{id}?hyperlinks=false")]
-        Task<T> GetById([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id);
+        Task<ApiResponse<T>> GetById([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id);
 
         [Get("/media/{id}/children?page={page}&pageSize={pageSize}&hyperlinks=false")]
-        Task<Delivery.Models.PagedMedia<T>> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, int page, int pageSize);
+        Task<ApiResponse<Delivery.Models.PagedMedia<T>>> GetChildren([Header(Constants.Headers.ProjectAlias)] string projectAlias, Guid id, int page, int pageSize);
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryService.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryService.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Net.Http;
-using Umbraco.Headless.Client.Net.Collections;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Refit;
 using Umbraco.Headless.Client.Net.Configuration;
-using Umbraco.Headless.Client.Net.Delivery.Models;
 using Umbraco.Headless.Client.Net.Security;
 
 namespace Umbraco.Headless.Client.Net.Delivery
@@ -69,9 +70,10 @@ namespace Umbraco.Headless.Client.Net.Delivery
             };
 
             var modelNameResolver = new ModelNameResolver();
+            var refitSettings = CreateRefitSettings(configuration, modelNameResolver);
 
-            Content = new ContentDelivery(configuration, httpClient, modelNameResolver);
-            Media = new MediaDelivery(configuration, httpClient, modelNameResolver);
+            Content = new ContentDelivery(configuration, httpClient, refitSettings, modelNameResolver);
+            Media = new MediaDelivery(configuration, httpClient, refitSettings);
         }
 
         /// <summary>
@@ -87,9 +89,10 @@ namespace Umbraco.Headless.Client.Net.Delivery
             };
 
             var modelNameResolver = new ModelNameResolver();
+            var refitSettings = CreateRefitSettings(configuration, modelNameResolver);
 
-            Content = new ContentDelivery(configuration, httpClient, modelNameResolver);
-            Media = new MediaDelivery(configuration, httpClient, modelNameResolver);
+            Content = new ContentDelivery(configuration, httpClient, refitSettings, modelNameResolver);
+            Media = new MediaDelivery(configuration, httpClient, refitSettings);
         }
 
         /// <summary>
@@ -103,9 +106,10 @@ namespace Umbraco.Headless.Client.Net.Delivery
         public ContentDeliveryService(IHeadlessConfiguration configuration, HttpClient httpClient)
         {
             var modelNameResolver = new ModelNameResolver();
+            var refitSettings = CreateRefitSettings(configuration, modelNameResolver);
 
-            Content = new ContentDelivery(configuration, httpClient, modelNameResolver);
-            Media = new MediaDelivery(configuration, httpClient, modelNameResolver);
+            Content = new ContentDelivery(configuration, httpClient, refitSettings, modelNameResolver);
+            Media = new MediaDelivery(configuration, httpClient, refitSettings);
         }
 
         /// <summary>
@@ -117,5 +121,18 @@ namespace Umbraco.Headless.Client.Net.Delivery
         /// Gets the Media part of the Content Delivery API
         /// </summary>
         public IMediaDelivery Media { get; }
+
+        private static RefitSettings CreateRefitSettings(IHeadlessConfiguration configuration, ModelNameResolver modelNameResolver)
+        {
+            return new RefitSettings
+            {
+                ContentSerializer = new JsonContentSerializer(new JsonSerializerSettings
+                {
+                    Formatting = Formatting.None,
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    Converters = configuration.GetJsonConverters(modelNameResolver)
+                })
+            };
+        }
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentPreviewService.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentPreviewService.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Net.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Refit;
 using Umbraco.Headless.Client.Net.Configuration;
 
 namespace Umbraco.Headless.Client.Net.Delivery
@@ -31,9 +34,10 @@ namespace Umbraco.Headless.Client.Net.Delivery
             };
 
             var modelNameResolver = new ModelNameResolver();
+            var refitSettings = CreateRefitSettings(configuration, modelNameResolver);
 
-            Content = new ContentDelivery(configuration, httpClient, modelNameResolver);
-            Media = new MediaDelivery(configuration, httpClient, modelNameResolver);
+            Content = new ContentDelivery(configuration, httpClient, refitSettings, modelNameResolver);
+            Media = new MediaDelivery(configuration, httpClient, refitSettings);
         }
 
         /// <summary>
@@ -45,5 +49,18 @@ namespace Umbraco.Headless.Client.Net.Delivery
         /// Gets the Media part of the Preview API
         /// </summary>
         public IMediaDelivery Media { get; }
+
+        private static RefitSettings CreateRefitSettings(IHeadlessConfiguration configuration, ModelNameResolver modelNameResolver)
+        {
+            return new RefitSettings
+            {
+                ContentSerializer = new JsonContentSerializer(new JsonSerializerSettings
+                {
+                    Formatting = Formatting.None,
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    Converters = configuration.GetJsonConverters(modelNameResolver)
+                })
+            };
+        }
     }
 }

--- a/src/Umbraco.Headless.Client.Net/Delivery/DeliveryBase.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/DeliveryBase.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using System.Threading.Tasks;
+using Refit;
+using Umbraco.Headless.Client.Net.Configuration;
+
+namespace Umbraco.Headless.Client.Net.Delivery
+{
+    internal abstract class DeliveryBase
+    {
+        protected DeliveryBase(IHeadlessConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        protected IHeadlessConfiguration Configuration { get; }
+
+        protected T GetResponse<T>(ApiResponse<T> response)
+        {
+            if (response.IsSuccessStatusCode)
+                return response.Content;
+
+            if (Configuration is HeadlessConfiguration headlessConfiguration)
+            {
+                if (headlessConfiguration.ApiExceptionDelegate != null)
+                {
+                    var context = new ApiExceptionContext
+                    {
+                        Exception = response.Error
+                    };
+                    headlessConfiguration.ApiExceptionDelegate(context);
+
+                    if (context.IsExceptionHandled || context.Exception == null) return default;
+                }
+            }
+
+            throw response.Error;
+        }
+    }
+}

--- a/src/Umbraco.Headless.Client.Net/Delivery/MediaDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/MediaDelivery.cs
@@ -1,77 +1,92 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Refit;
 using Umbraco.Headless.Client.Net.Configuration;
 using Umbraco.Headless.Client.Net.Delivery.Models;
 
 namespace Umbraco.Headless.Client.Net.Delivery
 {
-    internal class MediaDelivery : IMediaDelivery
+    internal class MediaDelivery : DeliveryBase, IMediaDelivery
     {
-        private readonly IHeadlessConfiguration _configuration;
         private readonly HttpClient _httpClient;
-        private readonly ModelNameResolver _modelNameResolver;
+        private readonly RefitSettings _refitSettings;
         private MediaDeliveryEndpoints _service;
 
-        public MediaDelivery(IHeadlessConfiguration configuration, HttpClient httpClient, ModelNameResolver modelNameResolver)
+        public MediaDelivery(IHeadlessConfiguration configuration, HttpClient httpClient, RefitSettings refitSettings) : base(configuration)
         {
-            _configuration = configuration;
             _httpClient = httpClient;
-            _modelNameResolver = modelNameResolver;
+            _refitSettings = refitSettings;
         }
 
         private MediaDeliveryEndpoints Service =>
-            _service
-            ?? (_service = RestService.For<MediaDeliveryEndpoints>(_httpClient,
-                new RefitSettings
-                {
-                    ContentSerializer = new JsonContentSerializer(new JsonSerializerSettings
-                    {
-                        Converters = _configuration.GetJsonConverters(_modelNameResolver)
-                    })
-                }));
+            _service ?? (_service = RestService.For<MediaDeliveryEndpoints>(_httpClient, _refitSettings));
 
         public async Task<IEnumerable<Media>> GetRoot()
         {
-            var root = await Service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
-            return root.Media.Items;
+            var result = await Get(x => x.GetRoot(Configuration.ProjectAlias)).ConfigureAwait(false);
+            return result?.Media.Items;
         }
 
         public async Task<IEnumerable<T>> GetRoot<T>() where T : IMedia
         {
-            var service = RestService.For<TypedMediaDeliveryEndpoints<T>>(_httpClient);
-            var root = await service.GetRoot(_configuration.ProjectAlias).ConfigureAwait(false);
-            return root.Media.Items;
+            var result = await GetTyped<T>(x => x.GetRoot(Configuration.ProjectAlias)).ConfigureAwait(false);
+            return result?.Media.Items;
         }
 
         public async Task<Media> GetById(Guid id)
         {
-            var content = await Service.GetById(_configuration.ProjectAlias, id).ConfigureAwait(false);
-            return content;
+            var result = await Get(x => x.GetById(Configuration.ProjectAlias, id)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<T> GetById<T>(Guid id) where T : IMedia
         {
-            var service = RestService.For<TypedMediaDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetById(_configuration.ProjectAlias, id).ConfigureAwait(false);
-            return content;
+            var result = await GetTyped<T>(x => x.GetById(Configuration.ProjectAlias, id)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<PagedMedia> GetChildren(Guid id, int page = 0, int pageSize = 10)
         {
-            var content = await Service.GetChildren(_configuration.ProjectAlias, id, page, pageSize).ConfigureAwait(false);
-            return content;
+            var result = await Get(x => x.GetChildren(Configuration.ProjectAlias, id, page, pageSize)).ConfigureAwait(false);
+            return result;
         }
 
         public async Task<PagedMedia<T>> GetChildren<T>(Guid id, int page = 0, int pageSize = 10) where T : IMedia
         {
+            var result = await GetTyped<T>(x => x.GetChildren(Configuration.ProjectAlias, id, page, pageSize)).ConfigureAwait(false);
+            return result;
+        }
+
+        private async Task<T> Get<T>(Func<MediaDeliveryEndpoints, Task<ApiResponse<T>>> getResponse)
+        {
+            using (var response = await getResponse(Service).ConfigureAwait(false))
+                return GetResponse(response);
+        }
+
+        private async Task<T> GetTyped<T>(Func<TypedMediaDeliveryEndpoints<T>, Task<ApiResponse<T>>> getResponse) where T : IMedia
+        {
             var service = RestService.For<TypedMediaDeliveryEndpoints<T>>(_httpClient);
-            var content = await service.GetChildren(_configuration.ProjectAlias, id, page, pageSize).ConfigureAwait(false);
-            return content;
+
+            using (var response = await getResponse(service).ConfigureAwait(false))
+                return GetResponse(response);
+        }
+
+        private async Task<RootMedia<T>> GetTyped<T>(Func<TypedMediaDeliveryEndpoints<T>, Task<ApiResponse<RootMedia<T>>>> getResponse) where T : IMedia
+        {
+            var service = RestService.For<TypedMediaDeliveryEndpoints<T>>(_httpClient);
+
+            using (var response = await getResponse(service).ConfigureAwait(false))
+                return GetResponse(response);
+        }
+
+        private async Task<PagedMedia<T>> GetTyped<T>(Func<TypedMediaDeliveryEndpoints<T>, Task<ApiResponse<PagedMedia<T>>>> getResponse) where T : IMedia
+        {
+            var service = RestService.For<TypedMediaDeliveryEndpoints<T>>(_httpClient);
+
+            using (var response = await getResponse(service).ConfigureAwait(false))
+                return GetResponse(response);
         }
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/TypedContentDeliveryFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/TypedContentDeliveryFixture.cs
@@ -115,6 +115,65 @@ namespace Umbraco.Headless.Client.Net.Tests
             }
         }
 
+        [Theory]
+        [InlineData("ca4249ed-2b23-4337-b522-63cabe5587d1")]
+        public async Task GetById_WhenNotFound_ReturnsNull(string id)
+        {
+            var contentId = Guid.Parse(id);
+            var service = new ContentDeliveryService(_configuration);
+
+            var content = await service.Content.GetById<Product>(contentId);
+
+            Assert.Null(content);
+        }
+
+        [Theory]
+        [InlineData("/my-page/")]
+        public async Task GetByUrl_WhenNotFound_ReturnsNull(string url)
+        {
+            var service = new ContentDeliveryService(_configuration);
+
+            var content = await service.Content.GetByUrl<Product>(url);
+
+            Assert.Null(content);
+        }
+
+        [Theory]
+        [InlineData("ca4249ed-2b23-4337-b522-63cabe5587d1")]
+        public async Task GetChildren_WhenNotFound_ReturnsNull(string id)
+        {
+            var contentId = Guid.Parse(id);
+            var service = new ContentDeliveryService(_configuration);
+
+            var content = await service.Content.GetChildren<Product>(contentId);
+
+            Assert.Null(content);
+        }
+
+        [Theory]
+        [InlineData("ca4249ed-2b23-4337-b522-63cabe5587d1")]
+        public async Task GetAncestors_WhenNotFound_ReturnsNull(string id)
+        {
+            var contentId = Guid.Parse(id);
+            var service = new ContentDeliveryService(_configuration);
+
+            var content = await service.Content.GetAncestors<Product>(contentId);
+
+            Assert.Null(content);
+        }
+
+        [Theory]
+        [InlineData("ca4249ed-2b23-4337-b522-63cabe5587d1")]
+        public async Task GetDescendants_WhenNotFound_ReturnsNull(string id)
+        {
+            var contentId = Guid.Parse(id);
+            var service = new ContentDeliveryService(_configuration);
+
+            var content = await service.Content.GetDescendants<Product>(contentId);
+
+            Assert.Null(content);
+        }
+
         private HttpClient GetMockedHttpClient(string url, string jsonResponse)
         {
             _mockHttp.When(url).Respond("application/json", jsonResponse);

--- a/test/Umbraco.Headless.Client.Net.Tests/TypedMediaDeliveryFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/TypedMediaDeliveryFixture.cs
@@ -56,6 +56,30 @@ namespace Umbraco.Headless.Client.Net.Tests
             }
         }
 
+        [Theory]
+        [InlineData("6d986832-fb11-4d65-b2ae-0d7742f27a19")]
+        public async Task GetById_WhenNotFound_ReturnsNull(string id)
+        {
+            var contentId = Guid.Parse(id);
+            var service = new ContentDeliveryService(_configuration);
+
+            var content = await service.Media.GetById<Folder>(contentId);
+
+            Assert.Null(content);
+        }
+
+        [Theory]
+        [InlineData("6d986832-fb11-4d65-b2ae-0d7742f27a19")]
+        public async Task GetChildren_WhenNotFound_ReturnsNull(string id)
+        {
+            var contentId = Guid.Parse(id);
+            var service = new ContentDeliveryService(_configuration);
+
+            var content = await service.Media.GetChildren<Folder>(contentId);
+
+            Assert.Null(content);
+        }
+
         private HttpClient GetMockedHttpClient(string url, string jsonResponse)
         {
             _mockHttp.When(url).Respond("application/json", jsonResponse);


### PR DESCRIPTION
Added the ability to add custom api exception handling, this can be done by overriding the `ApiExceptionDelegate` property on `HeadlessConfiguration`, the exception is available as `context.Exception` and contains all the data about the request and the reponse. 

By setting `context.IsExceptionHandled = true` the exception will not be thrown and the result returned from the services will be `null`, e.g.

```csharp
var configuration = new HeadlessConfiguration("my-project-alias")
{
    ApiExceptionDelegate = context => { context.IsExceptionHandled = true; }
};

var service = new ContentDeliveryService(configuration);
```

The default sets `context.IsExceptionHandled = true` if the response is a `404`

Right now this is only implemented for the `ContentDeliveryService` and `ContentPreviewService`