### PR TITLE
Fix preview cookie being cleared on each request

### DIFF
--- a/src/Umbraco.Headless.Client.Net.Web/DependencyInjection/UmbracoHeartcoreBuilder.cs
+++ b/src/Umbraco.Headless.Client.Net.Web/DependencyInjection/UmbracoHeartcoreBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using Umbraco.Headless.Client.Net.Configuration;
 using Umbraco.Headless.Client.Net.Delivery;
 using Umbraco.Headless.Client.Net.Management;
@@ -66,12 +67,19 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (configure != null) builder.Configure(configure);
 
+            var random = new Random();
+            byte[] bytes = new byte[32];
+            random.NextBytes(bytes);
+            var defaultSigningCredentials = new SigningCredentials(new SymmetricSecurityKey(bytes), SecurityAlgorithms.HmacSha256Signature);
+
             builder.Configure<IOptions<HeartcoreOptions>>((opts, config) =>
             {
                 opts.Enabled = true;
 
                 if (string.IsNullOrEmpty(opts.ApiKey) && config.Value.ApiKey != null)
                     opts.ApiKey = config.Value.ApiKey;
+
+                opts.SigningCredentials ??= defaultSigningCredentials;
             });
 
 

--- a/src/Umbraco.Headless.Client.Net.Web/HttpResponseExtensions.cs
+++ b/src/Umbraco.Headless.Client.Net.Web/HttpResponseExtensions.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Headless.Client.Net.Web
                 HttpOnly = true,
                 Secure = isDevelopment == false,
                 Path = "/",
-                SameSite = isDevelopment ? SameSiteMode.None : SameSiteMode.Lax,
+                SameSite = isDevelopment ? SameSiteMode.Unspecified : SameSiteMode.Lax,
                 MaxAge = options.MaxAge
             });
         }

--- a/src/Umbraco.Headless.Client.Net.Web/Options/PreviewOptions.cs
+++ b/src/Umbraco.Headless.Client.Net.Web/Options/PreviewOptions.cs
@@ -6,8 +6,6 @@ namespace Umbraco.Headless.Client.Net.Web.Options
 {
     public class PreviewOptions
     {
-        private SigningCredentials? _signingCredentials;
-
         internal bool Enabled { get; set; }
 
         /// <summary>
@@ -33,21 +31,7 @@ namespace Umbraco.Headless.Client.Net.Web.Options
         /// Get or set the <see cref="SigningCredentials"/> used to sign the preview cookie.
         /// The default is a random symmetric key that is generated each time the application starts.
         /// </summary>
-        public SigningCredentials SigningCredentials
-        {
-            get
-            {
-                if (_signingCredentials == null)
-                {
-                    var random = new Random();
-                    byte[] bytes = new byte[32];
-                    random.NextBytes(bytes);
-                    _signingCredentials = new SigningCredentials(new SymmetricSecurityKey(bytes), SecurityAlgorithms.HmacSha256Signature);
-                }
-
-                return _signingCredentials;
-            }
-            set => _signingCredentials = value;
-        }
+        [Required]
+        public SigningCredentials? SigningCredentials { get; set; }
     }
 }

--- a/src/Umbraco.Headless.Client.Net.Web/PreviewMiddleware.cs
+++ b/src/Umbraco.Headless.Client.Net.Web/PreviewMiddleware.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
@@ -10,12 +11,15 @@ namespace Umbraco.Headless.Client.Net.Web
 {
     public class PreviewMiddleware : IMiddleware
     {
+        private readonly ILogger<PreviewMiddleware> _logger;
         private readonly IOptions<PreviewOptions> _options;
         private readonly IUmbracoContext _umbracoContext;
         internal const string CookieName = "__umbraco_preview";
 
-        public PreviewMiddleware(IOptions<PreviewOptions> options, IUmbracoContext umbracoContext)
+        public PreviewMiddleware(ILogger<PreviewMiddleware> logger, IOptions<PreviewOptions> options,
+            IUmbracoContext umbracoContext)
         {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _umbracoContext = umbracoContext ?? throw new ArgumentNullException(nameof(umbracoContext));
         }
@@ -45,6 +49,7 @@ namespace Umbraco.Headless.Client.Net.Web
                 }
                 else
                 {
+                    _logger.LogDebug(result.Exception, "Preview cookie was not valid, exiting preview");
                     context.Response.ExitPreview();
                 }
             }


### PR DESCRIPTION
In the `PreviewController` we are injecting `IOptionsSnapshot<PreviewOptions>` meaning it'll be created for each request. This meant that the default key used to sign the `JWT` was regenerated each time the controller was hit, and hence different when it's validated in the `PreviewMiddleware`

This PR moves the generation of the `SigningCredentials` to the `AddPreview` method instead and sets it on the options if no user `SigningCredentials` is set