### PR TITLE
search incorrectly used the pagenumber as pageSize

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
@@ -152,7 +152,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
 
         public async Task<PagedContent> Search(string term, string culture = null, int page = 1, int pageSize = 10)
         {
-            var result = await Get(x => x.Search(Configuration.ProjectAlias, culture, term, page, page)).ConfigureAwait(false);
+            var result = await Get(x => x.Search(Configuration.ProjectAlias, culture, term, page, pageSize)).ConfigureAwait(false);
             return result;
         }
 


### PR DESCRIPTION
the page argument was passed on as the pageSize argument, so you could only get 1 result on page 1, 2 results on page 2,etc