### PR TITLE
Dispose content and response after sending requests

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Management/HttpClientExtensions.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/HttpClientExtensions.cs
@@ -10,19 +10,21 @@ namespace Umbraco.Headless.Client.Net.Management
         public static async Task<T> PostMultipartAsync<T>(this HttpClient client, IContentSerializer contentSerializer,
             string url, string projectAlias, object data, IDictionary<string, MultipartItem> files)
         {
-            var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false);
-
-            var response = await client.PostAsync(url, content).ConfigureAwait(false);
-            return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
+            using (var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false))
+            {
+                var response = await client.PostAsync(url, content).ConfigureAwait(false);
+                return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
+            }
         }
 
         public static async Task<T> PutMultipartAsync<T>(this HttpClient client, IContentSerializer contentSerializer,
             string url, string projectAlias, object data, IDictionary<string, MultipartItem> files)
         {
-            var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false);
-
-            var response = await client.PutAsync(url, content).ConfigureAwait(false);
-            return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
+            using (var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false))
+            {
+                var response = await client.PutAsync(url, content).ConfigureAwait(false);
+                return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
+            }
         }
 
         private static async Task<MultipartFormDataContent> CreateContent<T>(IContentSerializer contentSerializer, string projectAlias, object data,

--- a/src/Umbraco.Headless.Client.Net/Management/HttpClientExtensions.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/HttpClientExtensions.cs
@@ -11,8 +11,8 @@ namespace Umbraco.Headless.Client.Net.Management
             string url, string projectAlias, object data, IDictionary<string, MultipartItem> files)
         {
             using (var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false))
+            using (var response = await client.PostAsync(url, content).ConfigureAwait(false))
             {
-                var response = await client.PostAsync(url, content).ConfigureAwait(false);
                 return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
             }
         }
@@ -21,8 +21,8 @@ namespace Umbraco.Headless.Client.Net.Management
             string url, string projectAlias, object data, IDictionary<string, MultipartItem> files)
         {
             using (var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false))
+            using (var response = await client.PutAsync(url, content).ConfigureAwait(false))
             {
-                var response = await client.PutAsync(url, content).ConfigureAwait(false);
                 return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
The content and response need to be disposed. Otherwise, if you're sending files from disk (media for instance), they will be locked until the next application restart.