### PR TITLE
ContentDelivery GetByTypeAlias ignoring the contentTypeAlias parameter

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
@@ -125,7 +125,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         public async Task<PagedContent<T>> GetByTypeAlias<T>(string contentTypeAlias, string culture = null, int page = 1, int pageSize = 10) where T : IContent
         {
             if (string.IsNullOrWhiteSpace(contentTypeAlias))
-                throw new ArgumentException($"{nameof(contentTypeAlias)} cannot be null, empty or white space", contentTypeAlias);
+                throw new ArgumentException($"{nameof(contentTypeAlias)} cannot be null, empty or white space", nameof(contentTypeAlias));
 
             var result = await GetTyped<T>(x => x.GetByType(Configuration.ProjectAlias, culture, contentTypeAlias, page, pageSize)).ConfigureAwait(false);
             return result;

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDelivery.cs
@@ -124,9 +124,10 @@ namespace Umbraco.Headless.Client.Net.Delivery
 
         public async Task<PagedContent<T>> GetByTypeAlias<T>(string contentTypeAlias, string culture = null, int page = 1, int pageSize = 10) where T : IContent
         {
-            var contentType = GetAliasFromClassName<T>();
+            if (string.IsNullOrWhiteSpace(contentTypeAlias))
+                throw new ArgumentException($"{nameof(contentTypeAlias)} cannot be null, empty or white space", contentTypeAlias);
 
-            var result = await GetTyped<T>(x => x.GetByType(Configuration.ProjectAlias, culture, contentType, page, pageSize)).ConfigureAwait(false);
+            var result = await GetTyped<T>(x => x.GetByType(Configuration.ProjectAlias, culture, contentTypeAlias, page, pageSize)).ConfigureAwait(false);
             return result;
         }
 

--- a/test/Umbraco.Headless.Client.Net.Tests/TypedContentDeliveryFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/TypedContentDeliveryFixture.cs
@@ -80,16 +80,18 @@ namespace Umbraco.Headless.Client.Net.Tests
         {
             var service = new ContentDeliveryService(_configuration,
                 GetMockedHttpClient($"{_contentBaseUrl}/type?contentType={contentTypeAlias}", ContentDeliveryJson.GetByType));
-            var pagedContent = await service.Content.GetByTypeAlias<Product>(contentTypeAlias);
+            var pagedContent = await service.Content.GetByTypeAlias<Content>(contentTypeAlias);
             Assert.NotNull(pagedContent);
             Assert.NotNull(pagedContent.Content);
             Assert.NotEmpty(pagedContent.Content.Items);
             Assert.Equal(1, pagedContent.TotalPages);
             Assert.Equal(8, pagedContent.TotalItems);
+
+            
             foreach (var contentItem in pagedContent.Content.Items)
             {
                 Assert.NotNull(contentItem);
-                Assert.False(string.IsNullOrEmpty(contentItem.ProductName));
+                Assert.Equal(contentItem.ContentTypeAlias, contentTypeAlias);
             }
         }
 


### PR DESCRIPTION
Updated the GetByTypeAlias method of ContentDelivery to use the contentTypeAlias paramater instead of ignoring it.