### PR TITLE
Changes the Console implementation for image upload

### DIFF
--- a/samples/Umbraco.Headless.Client.Samples.Console/Umbraco.Headless.Client.Samples.Console/Program.cs
+++ b/samples/Umbraco.Headless.Client.Samples.Console/Umbraco.Headless.Client.Samples.Console/Program.cs
@@ -205,7 +205,7 @@ async Task UploadImageToMedia(ContentDeliveryService contentDeliveryService, str
 
     var media = new Umbraco.Headless.Client.Net.Management.Models.Media { Name = mediaName, MediaTypeAlias = mediaTypeAlias, ParentId = folderId };
 
-    object? rawPropertyValue;
+    object? rawPropertyValue = null;
 
     if (mediaTypeAlias == "Image")
         rawPropertyValue = new { src = fileName };

--- a/samples/Umbraco.Headless.Client.Samples.Console/Umbraco.Headless.Client.Samples.Console/Program.cs
+++ b/samples/Umbraco.Headless.Client.Samples.Console/Umbraco.Headless.Client.Samples.Console/Program.cs
@@ -205,7 +205,12 @@ async Task UploadImageToMedia(ContentDeliveryService contentDeliveryService, str
 
     var media = new Umbraco.Headless.Client.Net.Management.Models.Media { Name = mediaName, MediaTypeAlias = mediaTypeAlias, ParentId = folderId };
 
-    object? rawPropertyValue = isImageCropperUpload ? new { src = fileName } : isFileUpload ? fileName : null;
+    object? rawPropertyValue;
+
+    if (mediaTypeAlias == "Image")
+        rawPropertyValue = new { src = fileName };
+    else if (mediaTypeAlias == "File")
+        rawPropertyValue = fileName;
 
     media.SetValue("umbracoFile", rawPropertyValue, new FileInfoPart(new FileInfo(imagePath), fileName, $"image/{extension}"));
     var image = await managementService.Media.Create(media);

--- a/samples/Umbraco.Headless.Client.Samples.Console/Umbraco.Headless.Client.Samples.Console/Program.cs
+++ b/samples/Umbraco.Headless.Client.Samples.Console/Umbraco.Headless.Client.Samples.Console/Program.cs
@@ -190,17 +190,19 @@ async Task UploadImageToMedia(ContentDeliveryService contentDeliveryService, str
         folderId = folder.Id;
     }
 
-    var isImageCropperUpload = false;
-    var isFileUpload = false;
-    while (!isImageCropperUpload && !isFileUpload)
+    var mediaTypeAlias = "";
+    while (string.IsNullOrEmpty(mediaTypeAlias))
     {
         Console.WriteLine("Should the image be uploaded as an Image Cropper or a File? (image-cropper/file)");
         var uploadType = Console.ReadLine()?.ToLower();
-        isImageCropperUpload = uploadType.Equals("image-cropper");
-        isFileUpload = uploadType.Equals("file");
+        mediaTypeAlias = uploadType switch
+        {
+            "image-cropper" => "Image",
+            "file" => "File",
+            _ => ""
+        };
     }
 
-    var mediaTypeAlias = isImageCropperUpload ? "Image" : isFileUpload ? "File" : string.Empty;
     var media = new Umbraco.Headless.Client.Net.Management.Models.Media { Name = mediaName, MediaTypeAlias = mediaTypeAlias, ParentId = folderId };
 
     object? rawPropertyValue = isImageCropperUpload ? new { src = fileName } : isFileUpload ? fileName : null;

--- a/samples/Umbraco.Headless.Client.Samples.Console/Umbraco.Headless.Client.Samples.Console/Program.cs
+++ b/samples/Umbraco.Headless.Client.Samples.Console/Umbraco.Headless.Client.Samples.Console/Program.cs
@@ -276,7 +276,7 @@ async Task PageAndRenderDescendants(IContentDelivery contentDelivery, PagedConte
 
 void RenderContentWithUrl(Content content)
 {
-    Console.WriteLine("'" + content.Name + "' on " + content.Url);
+    Console.WriteLine($"'{content.Name}' on {content.Url}");
 }
 
 void RenderMediaWithUrl(Media media)


### PR DESCRIPTION
- Moved from username/password authentication to Api Key auth, as username and password auth is not working.
- Added an option to select whether the image should be uploaded as a File or an Image Cropper.

Uncommented lines that make the code fail. DeliveryService is not working as expected right now. It fails with no meaningfull error.