### PR TITLE
feat: upgrade refit to latest

### DIFF
--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryService.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentDeliveryService.cs
@@ -83,7 +83,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
             HttpMessageHandler httpMessageHandler = null;
             if (configuration is IPasswordBasedConfiguration passwordBasedConfiguration)
             {
-                var authenticationService = new AuthenticationService(configuration);
+                var authenticationService = new AuthenticationService(configuration, CreateRefitSettings());
                 var tokenResolver = new UserPasswordAccessTokenResolver(passwordBasedConfiguration.Username,
                     passwordBasedConfiguration.ProjectAlias, authenticationService);
                 httpMessageHandler = new AuthenticatedHttpClientHandler(tokenResolver);
@@ -139,11 +139,19 @@ namespace Umbraco.Headless.Client.Net.Delivery
         /// <inheritdoc/>
         public IRedirectDelivery Redirect { get; }
 
+        private static RefitSettings CreateRefitSettings()
+        {
+            return new RefitSettings
+            {
+                ContentSerializer = new NewtonsoftJsonContentSerializer()
+            };
+        }
+
         private static RefitSettings CreateRefitSettings(IHeadlessConfiguration configuration, ModelNameResolver modelNameResolver)
         {
             return new RefitSettings
             {
-                ContentSerializer = new JsonContentSerializer(new JsonSerializerSettings
+                ContentSerializer = new NewtonsoftJsonContentSerializer(new JsonSerializerSettings
                 {
                     Formatting = Formatting.None,
                     ContractResolver = new CamelCasePropertyNamesContractResolver(),

--- a/src/Umbraco.Headless.Client.Net/Delivery/ContentPreviewService.cs
+++ b/src/Umbraco.Headless.Client.Net/Delivery/ContentPreviewService.cs
@@ -71,7 +71,7 @@ namespace Umbraco.Headless.Client.Net.Delivery
         {
             return new RefitSettings
             {
-                ContentSerializer = new JsonContentSerializer(new JsonSerializerSettings
+                ContentSerializer = new NewtonsoftJsonContentSerializer(new JsonSerializerSettings
                 {
                     Formatting = Formatting.None,
                     ContractResolver = new CamelCasePropertyNamesContractResolver(),

--- a/src/Umbraco.Headless.Client.Net/Management/ContentManagementService.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/ContentManagementService.cs
@@ -42,7 +42,8 @@ namespace Umbraco.Headless.Client.Net.Management
         /// <param name="configureHttpClient">A delegate to configure the <see cref="HttpClient"/>.</param>
         public ContentManagementService(IPasswordBasedConfiguration configuration, Action<HttpClient> configureHttpClient = null)
         {
-            var authenticationService = new AuthenticationService(configuration);
+            var refitSettings = CreateRefitSettings();
+            var authenticationService = new AuthenticationService(configuration, CreateRefitSettings());
             var tokenResolver = new UserPasswordAccessTokenResolver(configuration.Username, configuration.ProjectAlias, authenticationService);
             var httpClient = new HttpClient(new AuthenticatedHttpClientHandler(tokenResolver))
             {
@@ -52,7 +53,6 @@ namespace Umbraco.Headless.Client.Net.Management
 
             if (configureHttpClient != null) configureHttpClient(httpClient);
 
-            var refitSettings = CreateRefitSettings();
 
             Content = new ContentService(configuration, httpClient, refitSettings);
             DocumentType = new DocumentTypeService(configuration, httpClient, refitSettings);
@@ -115,7 +115,7 @@ namespace Umbraco.Headless.Client.Net.Management
         {
             return new RefitSettings
             {
-                ContentSerializer = new JsonContentSerializer(new JsonSerializerSettings
+                ContentSerializer = new NewtonsoftJsonContentSerializer(new JsonSerializerSettings
                 {
                     Formatting = Formatting.None,
                     ContractResolver = new CamelCasePropertyNamesContractResolver()

--- a/src/Umbraco.Headless.Client.Net/Management/HttpClientExtensions.cs
+++ b/src/Umbraco.Headless.Client.Net/Management/HttpClientExtensions.cs
@@ -7,27 +7,27 @@ namespace Umbraco.Headless.Client.Net.Management
 {
     internal static class HttpClientExtensions
     {
-        public static async Task<T> PostMultipartAsync<T>(this HttpClient client, IContentSerializer contentSerializer,
+        public static async Task<T> PostMultipartAsync<T>(this HttpClient client, IHttpContentSerializer contentSerializer,
             string url, string projectAlias, object data, IDictionary<string, MultipartItem> files)
         {
-            using (var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false))
+            using (var content = CreateContent<T>(contentSerializer, projectAlias, data, files))
             using (var response = await client.PostAsync(url, content).ConfigureAwait(false))
             {
-                return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
+                return await contentSerializer.FromHttpContentAsync<T>(response.Content).ConfigureAwait(false);
             }
         }
 
-        public static async Task<T> PutMultipartAsync<T>(this HttpClient client, IContentSerializer contentSerializer,
+        public static async Task<T> PutMultipartAsync<T>(this HttpClient client, IHttpContentSerializer contentSerializer,
             string url, string projectAlias, object data, IDictionary<string, MultipartItem> files)
         {
-            using (var content = await CreateContent<T>(contentSerializer, projectAlias, data, files).ConfigureAwait(false))
+            using (var content = CreateContent<T>(contentSerializer, projectAlias, data, files))
             using (var response = await client.PutAsync(url, content).ConfigureAwait(false))
             {
-                return await contentSerializer.DeserializeAsync<T>(response.Content).ConfigureAwait(false);
+                return await contentSerializer.FromHttpContentAsync<T>(response.Content).ConfigureAwait(false);
             }
         }
 
-        private static async Task<MultipartFormDataContent> CreateContent<T>(IContentSerializer contentSerializer, string projectAlias, object data,
+        private static MultipartFormDataContent CreateContent<T>(IHttpContentSerializer contentSerializer, string projectAlias, object data,
             IDictionary<string, MultipartItem> files)
         {
             var content = new MultipartFormDataContent
@@ -37,7 +37,7 @@ namespace Umbraco.Headless.Client.Net.Management
                     {Constants.Headers.ProjectAlias, projectAlias}
                 },
             };
-            var postData = await contentSerializer.SerializeAsync(data).ConfigureAwait(false);
+            var postData = contentSerializer.ToHttpContent(data);
             content.Add(postData, "content");
             foreach (var file in files)
                 content.Add(file.Value.ToContent(), file.Key, file.Value.FileName);

--- a/src/Umbraco.Headless.Client.Net/Security/AuthenticatedHttpClientHandler.cs
+++ b/src/Umbraco.Headless.Client.Net/Security/AuthenticatedHttpClientHandler.cs
@@ -17,14 +17,6 @@ namespace Umbraco.Headless.Client.Net.Security
     {
         private readonly IAccessTokenResolver _accessTokenResolver;
 
-        [Obsolete("Use the overload that takes an ITokenResolver")]
-        public AuthenticatedHttpClientHandler(IPasswordBasedConfiguration configuration)
-        {
-            var authenticationService = new AuthenticationService(configuration);
-            _accessTokenResolver = new UserPasswordAccessTokenResolver(configuration.Username, configuration.Password, authenticationService);
-
-        }
-
         public AuthenticatedHttpClientHandler(IAccessTokenResolver accessTokenResolver, HttpMessageHandler handler = null) : base(handler)
         {
             _accessTokenResolver = accessTokenResolver ?? throw new ArgumentNullException(nameof(accessTokenResolver));

--- a/src/Umbraco.Headless.Client.Net/Umbraco.Headless.Client.Net.csproj
+++ b/src/Umbraco.Headless.Client.Net/Umbraco.Headless.Client.Net.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -16,8 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="refit" Version="4.7.51" />
-     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="refit" Version="8.0.0" />
+    <PackageReference Include="Refit.Newtonsoft.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/test/Umbraco.Headless.Client.Net.Tests/AuthenticatedHttpClientHandlerFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/AuthenticatedHttpClientHandlerFixture.cs
@@ -28,8 +28,8 @@ namespace Umbraco.Headless.Client.Net.Tests
                 .Respond("application/json", OAuthJson.GetToken);
 
             var configuration = new PasswordBasedConfiguration("myProject", "test@test.com", "}8N7aOE8#@");
-            var apiClient = new HttpClient(authMockHttp) {BaseAddress = new Uri(Constants.Urls.BaseApiUrl)};
-            var authenticationService = new AuthenticationService(configuration, apiHttpClient: apiClient);
+            var apiClient = new HttpClient(authMockHttp) {BaseAddress = new Uri(Constants.Urls.BaseApiUrl) };
+            var authenticationService = new AuthenticationService(configuration, RefitSettingsProvider.GetSettings(), apiHttpClient: apiClient);
 
             var handler = new AuthenticatedHttpClientHandler(
                 new UserPasswordAccessTokenResolver(configuration.Username, configuration.Password, authenticationService),
@@ -60,7 +60,7 @@ namespace Umbraco.Headless.Client.Net.Tests
                 .Respond("application/json", OAuthJson.GetToken);
 
             var cdnClient = new HttpClient(authMockHttp) {BaseAddress = new Uri(Constants.Urls.BaseCdnUrl)};
-            var authenticationService = new AuthenticationService("myProject", cdnHttpClient: cdnClient);
+            var authenticationService = new AuthenticationService("myProject", RefitSettingsProvider.GetSettings(), cdnHttpClient: cdnClient);
 
             var handler = new AuthenticatedHttpClientHandler(
                 new FuncAccessTokenResolver(async (_, __) => (await authenticationService.AuthenticateMember("janedoe", "g908&fgou#Pu9{@e")).AccessToken),

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/ContentServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/ContentServiceFixture.cs
@@ -318,6 +318,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private ContentService CreateService(HttpClient client) =>
-            new ContentService(_configuration, client, new RefitSettings());
+            new ContentService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/DocumentTypeServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/DocumentTypeServiceFixture.cs
@@ -114,6 +114,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private DocumentTypeService CreateService(HttpClient client) =>
-            new DocumentTypeService(_configuration, client, new RefitSettings());
+            new DocumentTypeService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/FormServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/FormServiceFixture.cs
@@ -148,6 +148,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
          }
 
          private FormService CreateService(HttpClient client) =>
-             new FormService(_configuration, client, new RefitSettings());
+             new FormService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/LanguageServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/LanguageServiceFixture.cs
@@ -116,6 +116,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private LanguageService CreateService(HttpClient client) =>
-            new LanguageService(_configuration, client, new RefitSettings());
+            new LanguageService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/MediaServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/MediaServiceFixture.cs
@@ -241,6 +241,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private MediaService CreateService(HttpClient client) =>
-            new MediaService(_configuration, client, new RefitSettings());
+            new MediaService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/MediaTypeServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/MediaTypeServiceFixture.cs
@@ -114,6 +114,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private MediaTypeService CreateService(HttpClient client) =>
-            new MediaTypeService(_configuration, client, new RefitSettings());
+            new MediaTypeService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/MemberGroupServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/MemberGroupServiceFixture.cs
@@ -90,6 +90,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private MemberGroupService CreateService(HttpClient client) =>
-            new MemberGroupService(_configuration, client, new RefitSettings());
+            new MemberGroupService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/MemberServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/MemberServiceFixture.cs
@@ -184,7 +184,7 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private MemberService CreateService(HttpClient client) =>
-            new MemberService(_configuration, client, new RefitSettings());
+            new MemberService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/MemberTypeServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/MemberTypeServiceFixture.cs
@@ -148,6 +148,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private MemberTypeService CreateService(HttpClient client) =>
-            new MemberTypeService(_configuration, client, new RefitSettings());
+            new MemberTypeService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/RelationServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/RelationServiceFixture.cs
@@ -174,6 +174,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private RelationService CreateService(HttpClient client) =>
-            new RelationService(_configuration, client, new RefitSettings());
+            new RelationService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/Management/RelationTypeServiceFixture.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/Management/RelationTypeServiceFixture.cs
@@ -59,6 +59,6 @@ namespace Umbraco.Headless.Client.Net.Tests.Management
         }
 
         private RelationTypeService CreateService(HttpClient client) =>
-            new RelationTypeService(_configuration, client, new RefitSettings());
+            new RelationTypeService(_configuration, client, RefitSettingsProvider.GetSettings());
     }
 }

--- a/test/Umbraco.Headless.Client.Net.Tests/RefitSettingsProvider.cs
+++ b/test/Umbraco.Headless.Client.Net.Tests/RefitSettingsProvider.cs
@@ -1,0 +1,12 @@
+﻿using Refit;
+
+namespace Umbraco.Headless.Client.Net.Tests
+{
+    public static class RefitSettingsProvider
+    {
+        public static RefitSettings GetSettings()
+        {
+            return new RefitSettings { ContentSerializer = new NewtonsoftJsonContentSerializer() };
+        }
+    }
+}

--- a/test/Umbraco.Headless.Client.Net.Tests/Umbraco.Headless.Client.Net.Tests.csproj
+++ b/test/Umbraco.Headless.Client.Net.Tests/Umbraco.Headless.Client.Net.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="refit" Version="4.7.51" />
+    <PackageReference Include="refit" Version="8.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
Updated Refit dependency to close off potential security vulnerability. (Note that we don't use the vulnerable method, but there's a danger of someone seeing its use as a transient dependency and using the vulnerable method in their own code)

Refit 8+ support both Newtonsoft.JSON and System.Text.Json, so most of this is just passing around the Newtonsoft serializer on options.

I'm really not a big fan of the fact that there's minimal DI set up to inject things like these settings, but I was surgical about the change because that would have been a much larger effort to correct.

Needs further testing before merge.